### PR TITLE
Make CentOS7 Compatible

### DIFF
--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -5,10 +5,15 @@
     - '/usr/local/sbin'
     - '/usr/local/bin'
     - '/usr/sbin'
-    - '/usr/bin' 
+    - '/usr/bin'
+    - '{{os_env_extra_user_paths}}'
+
+- name: minimize access for non CentOS7 Systems
+  file: path='{{item}}' mode='go-w' recurse=yes
+  with_items:
     - '/sbin'
     - '/bin'
-    - '{{os_env_extra_user_paths}}'
+  when: not "(ansible_distribution is 'CentOS' and ansible_distribution_major_version is '7')"
 
 - name: change shadow ownership to root and mode to 0600 | DTAG SEC Req 3.21-7
   file: dest='/etc/shadow' owner=root group=root mode=0600

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -37,5 +37,6 @@
     state: present
     reload: yes
     ignoreerrors: yes
+  ignore_errors: yes
   with_dict: sysctl_rhel_config
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'CentOS'


### PR DESCRIPTION
This PR has two commits.

## Seperated 'minimize access' folders for CentOS7 which are now symlinks
This is in reply to #71 

## CentOS7 exec-shield can't be turned off.
This is in reply to #74 
Quote from Red Hat:

> Exec-shield is no longer an option in sysctl for kernel tuning.
> This is a security measure, as documented in the RHEL 7 Security Guide.

So it's definitely active, if the Hardware supports it.

Tested with Ansible 2.0.1