### PR TITLE
fix bare variables usage for loops

### DIFF
--- a/tasks/rhosts.yml
+++ b/tasks/rhosts.yml
@@ -6,7 +6,7 @@
 
 - name: delete rhosts-files from system | DTAG SEC Req 3.21-4
   file: dest='~{{ item }}/.rhosts' state=absent
-  with_items: users.stdout_lines
+  with_items: '{{ users.stdout_lines }}'
 
 - name: delete hosts.equiv from system | DTAG SEC Req 3.21-4
   file: dest='/etc/hosts.equiv' state=absent

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -23,7 +23,7 @@
     state: present
     reload: yes
     ignoreerrors: yes
-  with_dict: sysctl_config
+  with_dict: '{{ sysctl_config }}'
 
 - name: Change various sysctl-settings on rhel-hosts, look at the sysctl-vars file for documentation
   sysctl:
@@ -33,5 +33,5 @@
     state: present
     reload: yes
     ignoreerrors: yes
-  with_dict: sysctl_rhel_config
+  with_dict: '{{ sysctl_rhel_config }}'
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'CentOS'


### PR DESCRIPTION
Opened issue: https://github.com/dev-sec/ansible-os-hardening/issues/78

> TASK [ansible-os-hardening : delete rhosts-files from system | DTAG SEC Req 3.21-4] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full 
variable syntax ('{{users.stdout_lines}}').
This feature will be removed in a future release. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.

> TASK [ansible-os-hardening : Change various sysctl-settings on rhel-hosts, look at the sysctl-vars file for documentation] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full 
variable syntax ('{{sysctl_rhel_config}}').
This feature will be removed in a future release. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.

> TASK [ansible-os-hardening : Change various sysctl-settings, look at the sysctl-vars file for documentation] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full 
variable syntax ('{{sysctl_config}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
