### PR TITLE
replace ignore_errors to failed_when to supress ugly error warnings

### DIFF
--- a/tasks/suid_sgid.yml
+++ b/tasks/suid_sgid.yml
@@ -1,7 +1,7 @@
 ---
 - name: remove suid/sgid bit from binaries in blacklist
   file: path='{{item}}' mode='a-s' state=file follow=yes
-  ignore_errors: true
+  failed_when: false
   with_items:
     - '{{ os_security_suid_sgid_system_blacklist }}'
     - '{{ os_security_suid_sgid_blacklist }}'


### PR DESCRIPTION
Before: 
![errors](https://cloud.githubusercontent.com/assets/10243861/15401649/a7504282-1e1a-11e6-9fb9-978983cd9900.png)

After:
![noerrors](https://cloud.githubusercontent.com/assets/10243861/15401674/c41d93ec-1e1a-11e6-8a5e-34900e1af63f.png)