### PR TITLE
Skip perms changes to /etc/shadow on desktop machines

### DIFF
--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -12,6 +12,7 @@
 
 - name: change shadow ownership to root and mode to 0600 | DTAG SEC Req 3.21-7
   file: dest='/etc/shadow' owner=root group=root mode=0600
+  when: os_desktop_enable == false
 
 - name: change su-binary to only be accessible to user and group root
   file: dest='/bin/su' owner=root group=root mode=0750


### PR DESCRIPTION
When the `os_desktop_enable` var is set to true, skip locking down
/etc/shadow to root:root 0600. Interactive workstations may assume a
root:shadow 0640 setup, which leverages setgid on `/sbin/unix_chkpwd`
to read the password as a normal user.

Closes #86.