### PR TITLE
debian 8 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,9 @@
 ---
 driver:
   name: vagrant
+
 provisioner:
   name: ansible_playbook
-  test_repo_uri: https://github.com/hardening-io/tests-os-hardening.git
   hosts: all
   require_ansible_repo: false
   require_ansible_omnibus: true
@@ -11,8 +11,15 @@ provisioner:
   require_ruby_for_busser: false
   ansible_verbose: true
   ansible_diff: true
+  hosts: all
   roles_path: ../ansible-os-hardening/
-  playboo: default.yml
+  playbook: default.yml
+
+verifier:
+  name: inspec
+  sudo: true
+  inspec_tests:
+    - https://github.com/dev-sec/tests-os-hardening
 
 platforms:
 - name: ubuntu-12.04
@@ -39,10 +46,6 @@ platforms:
   driver_config:
     box: oracle-6.5
     box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-- name: debian-6
-  driver_config:
-    box: debian-6
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box
 - name: debian-7
   driver_config:
     box: debian-7
@@ -51,10 +54,9 @@ platforms:
   driver_config:
     box: debian-8
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box
-verifier:
-  name: inspec
+
 suites:
-- name: ansible_1.9
+- name: os-ansible_1.9
   provisioner:
     ansible_version: 1.9.4
-- name: ansible_latest
+- name: os-ansible_latest

--- a/default.yml
+++ b/default.yml
@@ -1,4 +1,20 @@
 ---
+- name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
+  hosts: localhost
+  roles:
+    - ansible-os-hardening
+  vars:
+    os_security_users_allow: change_user
+    os_security_kernel_enable_core_dump: true
+    os_security_suid_sgid_remove_from_unknown: true
+    os_auth_pam_passwdqc_enable: false
+    os_desktop_enable: true
+    os_env_extra_user_paths: ['/home']
+    os_auth_allow_homeless: true
+    os_security_kernel_enable_core_dump: true
+    os_security_suid_sgid_blacklist: ['/bin/umount']
+    os_security_suid_sgid_whitelist: ['/usr/bin/rlogin']
+
 - name: wrapper playbook for kitchen testing "ansible-os-hardening"
   hosts: localhost
   roles:


### PR DESCRIPTION
I implemented Debian 8 support (and removed debian 6 support, since its EOL) as well as making it easier to locally test the role with inspec.