### PR TITLE
Permits overriding permissions on /etc/shadow

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,14 @@ os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 999
 
+# Different distros use different standards for /etc/shadow perms, e.g.
+# RHEL derivatives use root:root 0600, whereas Debian-based use root:shadow 0640.
+# You must provide key/value pairs for owner, group, and mode if overriding.
+os_shadow_perms:
+  owner: root
+  group: root
+  mode: "0600"
+
 os_chfn_restrict: ''
 # may contain: change_user
 os_security_users_allow: []

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -11,7 +11,7 @@
     - '{{os_env_extra_user_paths}}'
 
 - name: change shadow ownership to root and mode to 0600 | DTAG SEC Req 3.21-7
-  file: dest='/etc/shadow' owner=root group=root mode=0600
+  file: dest='/etc/shadow' owner={{ os_shadow_perms.owner }} group={{ os_shadow_perms.group }} mode={{ os_shadow_perms.mode }}
 
 - name: change su-binary to only be accessible to user and group root
   file: dest='/bin/su' owner=root group=root mode=0750


### PR DESCRIPTION
To support a variety of distros, some of which recommend root:root 0600
permissions on the shadow file (RHEL-based) and others root:shadow
0640 (Debian-based), allow users to override the /etc/shadow owner,
group, and mode via a dict var.

Closes #86.