### PR TITLE
Adds support for CentOS 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,10 @@ platforms:
   driver_config:
     box: opscode-centos-6.5
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+- name: centos-7.2
+  driver_config:
+    box: opscode-centos-7.2
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.2_chef-provisionerless.box
 - name: oracle-6.4
   driver_config:
     box: oracle-6.4

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -1,14 +1,22 @@
 ---
-- name: minimize access
-  file: path='{{item}}' mode='go-w' recurse=yes
+# Using a two-pass approach for checking directories in order to support symlinks.
+- name: find directories for minimizing access
+  stat:
+    path: "{{ item }}"
+  register: minimize_access_directories
   with_items:
     - '/usr/local/sbin'
     - '/usr/local/bin'
     - '/usr/sbin'
-    - '/usr/bin' 
+    - '/usr/bin'
     - '/sbin'
     - '/bin'
     - '{{os_env_extra_user_paths}}'
+
+- name: minimize access
+  file: path='{{item.stat.path}}' mode='go-w' recurse=yes
+  when: item.stat.isdir
+  with_items: "{{ minimize_access_directories.results }}"
 
 - name: change shadow ownership to root and mode to 0600 | DTAG SEC Req 3.21-7
   file: dest='/etc/shadow' owner={{ os_shadow_perms.owner }} group={{ os_shadow_perms.group }} mode={{ os_shadow_perms.mode }}

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -29,7 +29,6 @@
   sysctl:
     name: '{{ item.key }}'
     value: '{{ item.value }}'
-    sysctl_set: yes
     state: present
     reload: yes
     ignoreerrors: yes


### PR DESCRIPTION
CentOS 7 introduced some breaking changes for the role, namely:

* symlinks for system dirs: `/bin` -> `/usr/bin`, `/sbin` -> `/usr/sbin`
* `kernel.exec_shield` sysctl parameter no longer configurable

This PR addresses the changes and provides backwards-compatible support for CentOS 7. Of particular note is the undocumented behavior of the sysctl Ansible module where use of the "sysctl_set" parameter overrides the "ignoreerrors" parameter. Was maddening to debug, but got to the bottom of it eventually.

There are still a few failing tests here, but pending inclusion of the new inspec suite and potentially the docker integration, I'm submitting anyway. The PR does indeed fix a few outstanding issues, so it warrants review for inclusion.

Fixes #71. Fixes #74. Supersedes and therefore closes #77.