### PR TITLE
Supports --check mode

### DIFF
--- a/tasks/rhosts.yml
+++ b/tasks/rhosts.yml
@@ -2,6 +2,7 @@
 - name: Get user accounts | DTAG SEC Req 3.21-4
   command: "awk -F: '{print $1}' /etc/passwd"
   changed_when: False
+  always_run: True
   register: users
 
 - name: delete rhosts-files from system | DTAG SEC Req 3.21-4

--- a/tasks/user_accounts.yml
+++ b/tasks/user_accounts.yml
@@ -3,6 +3,7 @@
 - name: get UID_MIN from login.defs
   shell: awk '/^\s*UID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs removes=/etc/login.defs
   register: uid_min
+  always_run: True
   changed_when: False
 
 - name: calculate UID_MAX from UID_MIN by substracting 1
@@ -20,6 +21,7 @@
 - name: get all system accounts
   command: awk -F'':'' '{ if ( $3 <= {{uid_max|quote}} ) print $1}' /etc/passwd removes=/etc/passwd 
   changed_when: False
+  always_run: True
   register: sys_accs
 
 - name: remove always ignored system accounts from list 


### PR DESCRIPTION
By setting always_run=true on a few read-only tasks that are used to
register variables, we add support for dry runs of the role via the
--check flag to ansible-playbook. The role now completes without error
in dry-run mode, which is very useful when onboarding new hosts to the
role.