### PR TITLE
Install SELinux python bindings when SELinux is enabled

### DIFF
--- a/tasks/login_defs.yml
+++ b/tasks/login_defs.yml
@@ -1,4 +1,8 @@
 ---
+- name: install SELinux python bindings if SELinux is enabled
+  package: name={{os_packages_libselinux_python}} state=present
+  when: ansible_selinux.status == 'enabled'
+
 - name: create login.defs
   template: src='login.defs.j2' dest='/etc/login.defs' owner=root group=root mode=0444
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,7 @@
 os_packages_pam_ccreds: 'libpam-ccreds'
 os_packages_pam_passwdqc: 'libpam-passwdqc'
 os_packages_pam_cracklib: 'libpam-cracklib'
+os_packages_libselinux_python: 'python-selinux'
 passwdqc_path: '/usr/share/pam-configs/passwdqc'
 tally2_path: '/usr/share/pam-configs/tally2'
 os_nologin_shell_path: '/usr/sbin/nologin'

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,4 +1,5 @@
 os_packages_pam_ccreds:  'pam_ccreds'
 os_packages_pam_passwdqc:  'pam_passwdqc'
 os_packages_pam_cracklib:  'pam_cracklib'
+os_packages_libselinux_python: 'libselinux-python'
 os_nologin_shell_path: '/sbin/nologin'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,5 @@
 os_packages_pam_ccreds:  'pam_ccreds'
 os_packages_pam_passwdqc:  'pam_passwdqc'
 os_packages_pam_cracklib:  'pam_cracklib'
+os_packages_libselinux_python: 'libselinux-python'
 os_nologin_shell_path: '/sbin/nologin'


### PR DESCRIPTION
This is apparently required by login_defs, CentOS 7 minimal install fails here without it