### PR TITLE
Remove Ansible 1.9 support

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -55,7 +55,4 @@ verifier:
     - https://github.com/dev-sec/tests-os-hardening
 
 suites:
-- name: os-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
 - name: os-ansible_latest

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,7 +59,4 @@ verifier:
     - https://github.com/dev-sec/tests-os-hardening
 
 suites:
-- name: os_ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
 - name: os_ansible_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python: "2.7"
 
 env:
   - ANSIBLE_VERSION=latest
-  - ANSIBLE_VERSION=1.9.4
 
 before_install:
  - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,5 @@ install:
   - echo -e '[defaults]\nroles_path = ../\nhostfile = ./spec/inventory' > ansible.cfg
 
 script:
-  - ansible-playbook --syntax-check spec/travis.yml
-  - ansible-playbook --sudo -v --diff spec/travis.yml --skip-tags "sysctl" --extra-vars "os_security_users_allow=change_user os_security_kernel_enable_core_dump=true os_security_suid_sgid_remove_from_unknown=true"
-  - ansible-playbook --sudo -v --diff spec/travis.yml --tags "pam" --extra-vars "os_auth_pam_passwdqc_enable=false"
-  - ansible-playbook --sudo -v --diff spec/travis.yml --skip-tags "sysctl" --extra-vars "os_security_users_allow=change_user"
+  - ansible-playbook --syntax-check default.yml
+  - ansible-playbook --sudo -v --diff default.yml --skip-tags "sysctl"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Change Log
 
-## [Unreleased](https://github.com/dev-sec/ansible-os-hardening/tree/HEAD)
+## [3.2.0](https://github.com/dev-sec/ansible-os-hardening/tree/3.2.0) (2016-10-24)
+[Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/3.1.0...3.2.0)
 
-[Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/3.0.0...HEAD)
+**Fixed bugs:**
+
+- CentOS 7 selinux dependencies [\#102](https://github.com/dev-sec/ansible-os-hardening/issues/102)
+- ubuntu xenial warning during activate gpg-check for yum-repos [\#99](https://github.com/dev-sec/ansible-os-hardening/issues/99)
+- rhel\_system\_auth.j2 is still using pam\_passwdqc.so for CentOS 7 [\#98](https://github.com/dev-sec/ansible-os-hardening/issues/98)
+- Enable pam\_pwquality in rhel-family \> 7 [\#73](https://github.com/dev-sec/ansible-os-hardening/issues/73)
+- "irc" user always changed after reboot [\#53](https://github.com/dev-sec/ansible-os-hardening/issues/53)
+
+**Merged pull requests:**
+
+- update template [\#101](https://github.com/dev-sec/ansible-os-hardening/pull/101) ([rndmh3ro](https://github.com/rndmh3ro))
+- fix deprecation warning for undefined error. \#99 [\#100](https://github.com/dev-sec/ansible-os-hardening/pull/100) ([rndmh3ro](https://github.com/rndmh3ro))
+- add rhel7 pam\_pwquality. fix \#73 [\#94](https://github.com/dev-sec/ansible-os-hardening/pull/94) ([rndmh3ro](https://github.com/rndmh3ro))
+
+## [3.1.0](https://github.com/dev-sec/ansible-os-hardening/tree/3.1.0) (2016-08-03)
+[Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/3.1...3.1.0)
+
+## [3.1](https://github.com/dev-sec/ansible-os-hardening/tree/3.1) (2016-07-27)
+[Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/3.0.0...3.1)
 
 **Implemented enhancements:**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It will not:
 
 ## Requirements
 
-* Ansible
+* Ansible 2.2
 
 ## Variables
 

--- a/default.yml
+++ b/default.yml
@@ -6,7 +6,6 @@
   vars:
     deploy_security_rules: false
   roles:
-    - ansible-os-hardening
     - { role: ansible-os-hardening, when: deploy_security_rules }
 
 # run in check mode

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: 'This Ansible playbook provides numerous security-related configurations, providing all-round base protection.'
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: '1.9'
+  min_ansible_version: '2.2'
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
This removes Ansible 1.9 support.
This uses the same (therefore more) tests as locally testing, simplifying the config somewhat.