### PR TITLE
use new Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
-README.pdf
-README.html
-shared_test_repo/
-test/integration
 .kitchen
-coverage
-Vagrantfile.erb
-
-Gemfile.lock
-Berksfile.lock
-
-ansible.cfg
 hosts
+Gemfile.lock

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -9,7 +9,6 @@ driver:
 
 provisioner:
   name: ansible_playbook
-  test_repo_uri: https://github.com/hardening-io/tests-os-hardening.git
   hosts: all
   require_ansible_repo: false
   require_ansible_omnibus: true
@@ -21,6 +20,9 @@ provisioner:
   http_proxy: <%= ENV['http_proxy'] || nil %>
   https_proxy: <%= ENV['https_proxy'] || nil %>
 
+transport:
+  max_ssh_sessions: 5
+
 platforms:
 - name: ubuntu-12.04
   driver_config:
@@ -30,6 +32,10 @@ platforms:
   driver_config:
     box: opscode-ubuntu-14.04
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+- name: ubuntu-16.04
+  driver_config:
+    box: opscode-ubuntu-16.04
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4
@@ -68,10 +74,7 @@ verifier:
   name: inspec
   sudo: true
   inspec_tests:
-    - https://github.com/dev-sec/tests-os-hardening
+    - https://github.com/dev-sec/linux-baseline/
 
 suites:
-- name: os-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: os-ansible_latest
+- name: os

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,6 @@ provisioner:
   name: ansible_playbook
   hosts: all
   require_ansible_repo: false
-  require_ansible_omnibus: true
   require_chef_for_busser: false
   require_ruby_for_busser: false
   ansible_verbose: true
@@ -27,44 +26,46 @@ provisioner:
     - "--skip-tags=sysctl"
 
 platforms:
-- name: ubuntu-12.04
+- name: centos6-ansible-latest
   driver:
-    image: ubuntu:12.04
-- name: ubuntu-14.04
+    image: rndmh3ro/docker-centos6-ansible:latest
+    platform: centos
+- name: centos7-ansible-latest
   driver:
-    image: ubuntu:14.04
-- name: ubuntu-16.04
+    image: rndmh3ro/docker-centos7-ansible:latest
+    platform: centos
+- name: oracle6-ansible-latest
   driver:
-    image: ubuntu:16.04
-    provision_command:
-      - "apt-get install initramfs-tools -y"
-- name: centos-6.6
+    image: rndmh3ro/docker-oracle6-ansible:latest
+    platform: centos
+- name: oracle7-ansible-latest
   driver:
-    image: centos:6.6
-- name: centos-6.7
+    image: rndmh3ro/docker-oracle7-ansible:latest
+    platform: centos
+- name: ubuntu1204-ansible-latest
   driver:
-    image: centos:6.7
-- name: centos-7
+    image: rndmh3ro/docker-ubuntu1204-ansible:latest
+    platform: ubuntu
+- name: ubuntu1404-ansible-latest
   driver:
-    image: centos:7
-    privileged: true
-    run_command: /usr/sbin/init
-- name: oracle-6
+    image: rndmh3ro/docker-ubuntu1404-ansible:latest
+    platform: ubuntu
+- name: ubuntu1604-ansible-latest
   driver:
-    image: oraclelinux:6
-    platform: rhel
-- name: oracle-7
+    image: rndmh3ro/docker-ubuntu1604-ansible:latest
+    platform: ubuntu
+- name: debian7-ansible-latest
   driver:
-    image: oraclelinux:7
-    platform: rhel
-    privileged: true
-    run_command: /usr/sbin/init
-- name: debian-7
+    image: rndmh3ro/docker-debian7-ansible:latest
+    platform: debian
+- name: debian8-ansible-latest
   driver:
-    image: debian:7
-- name: debian-8
+    image: rndmh3ro/docker-debian8-ansible:latest
+    platform: debian
+- name: debian9-ansible-latest
   driver:
-    image: debian:8
+    image: rndmh3ro/docker-debian9-ansible:latest
+    platform: debian
 
 verifier:
   name: inspec
@@ -73,7 +74,4 @@ verifier:
     - https://github.com/dev-sec/tests-os-hardening
 
 suites:
-- name: os_ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: os_ansible_latest
+- name: os

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,65 @@
 ---
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
-language: python
-python: "2.7"
+services: docker
 
 env:
-  - ANSIBLE_VERSION=latest
-  - ANSIBLE_VERSION=1.9.4
+  - distro: centos6
+    version: latest
+    init: /sbin/init
+
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
+  - distro: oracle6
+    version: latest
+    init: /sbin/init
+
+  - distro: oracle7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
+  - distro: ubuntu1604
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: ubuntu1404
+    version: latest
+    init: /sbin/init
+
+  - distro: ubuntu1204
+    version: latest
+    init: /sbin/init
+
+  - distro: debian7
+    version: latest
+    init: /sbin/init
+
+  - distro: debian8
+    version: latest
+    init: /sbin/init
+
+  - distro: debian9
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
-install:
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
-  - echo -e 'localhost ansible_connection=local' > spec/inventory
-  - echo -e '[defaults]\nroles_path = ../\nhostfile = ./spec/inventory' > ansible.cfg
+  # Pull container
+  - 'docker pull rndmh3ro/docker-${distro}-ansible:${version}'
 
 script:
-  - ansible-playbook --syntax-check spec/travis.yml
-  - ansible-playbook --sudo -v --diff spec/travis.yml --skip-tags "sysctl" --extra-vars "os_security_users_allow=change_user os_security_kernel_enable_core_dump=true os_security_suid_sgid_remove_from_unknown=true"
-  - ansible-playbook --sudo -v --diff spec/travis.yml --tags "pam" --extra-vars "os_auth_pam_passwdqc_enable=false"
-  - ansible-playbook --sudo -v --diff spec/travis.yml --skip-tags "sysctl" --extra-vars "os_security_users_allow=change_user"
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-os-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
+
+  # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-os-hardening/default.yml --skip-tags "sysctl"'
+
+  # Verify role
+  - 'inspec exec https://github.com/dev-sec/linux-baseline/ -t docker://$(cat ${container_id}) --controls=os-01 os-02 os-03 os-04 os-05 os-06 os-07 package-01 package-02 package-03 package-04 package-05 package-06'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,6 @@
 
 source 'https://rubygems.org'
 
-group :test do
-  gem 'rake'
-  gem 'foodcritic', '~> 4.0'
-  gem 'thor-foodcritic'
-  gem 'coveralls',  require: false
-end
-
-group :development do
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'guard-kitchen'
-end
-
 group :integration do
   gem 'test-kitchen', '~> 1.0'
   gem 'kitchen-ansible'
@@ -24,10 +11,6 @@ group :integration do
   gem 'kitchen-sync'
   gem 'kitchen-transport-rsync'
   gem 'kitchen-docker'
-end
-
-group :openstack do
-  gem 'kitchen-openstack'
 end
 
 group :tools do

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It will not:
 
 ## Requirements
 
-* Ansible
+* Ansible 2.2.1
 
 ## Variables
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,15 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook 
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+ansible_managed = Ansible managed: {file} modified on %Y-%m-%d by {uid} on {host}
+
+# additional paths to search for roles in, colon separated
+roles_path    = ../
+

--- a/kitchen_vagrant_block.rb
+++ b/kitchen_vagrant_block.rb
@@ -1,15 +1,5 @@
 # This is a Vagrant block to allow proxy settings to be carried into Kitchen
 # You need this for all of yum/apt etc. to work!
-unless ENV['http_proxy'].empty? || Vagrant.has_plugin?("vagrant-proxyconf")
-  raise "Missing required plugin 'vagrant-proxyconf' to support HTTP(S) proxies, run `vagrant plugin install vagrant-proxyconf`"
-end
 
 Vagrant.configure(2) do |config|
-  config.proxy.http     = "#{ENV['http_proxy']}"
-  config.proxy.https    = "#{ENV['https_proxy']}"
-  config.proxy.no_proxy = "localhost,127.0.0.1"
-
-  # You may have vagrant-vbguest plugin installed to keep your images up to date
-  # - but will probably have VBoxAddition build issues with the foreign boxes listed in .kitchen.vagrant.yml
-  config.vbguest.auto_update = false
 end

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: 'This Ansible role provides numerous security-related configurations, providing all-round base protection.'
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: '1.9'
+  min_ansible_version: '2.2.1'
   platforms:
     - name: EL
       versions:

--- a/spec/travis.yml
+++ b/spec/travis.yml
@@ -1,3 +1,0 @@
-- hosts: localhost
-  roles:
-    - ansible-os-hardening

--- a/tasks/pam.yml
+++ b/tasks/pam.yml
@@ -19,7 +19,7 @@
   when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and os_auth_pam_passwdqc_enable
 
 - name: install the package for strong password checking
-  apt: name='{{os_packages_pam_passwdqc}}' state='installed'
+  apt: name='{{os_packages_pam_passwdqc}}' state='installed' update_cache='yes'
   when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and os_auth_pam_passwdqc_enable
 
 - name: configure passwdqc


### PR DESCRIPTION
This uses my own docker images (https://github.com/rndmh3ro/docker-ansible). These are just the base images with pre-installed Docker to save time and hassle when testing the roles.
This also enables full travis testing of all supported operating systems!

This too removes ansible 1.9 support, to better test the role. Also there's no more support for Ansible < 2.0, see https://groups.google.com/forum/#!topic/ansible-devel/6-6FdxZ94kc.

I'll update the PR accordingly when #108 is merged.
#106 is also applied here for testing purposes.