### PR TITLE
Fix ansible.cfg and use comment filter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,8 +8,9 @@
 # finds first
 
 [defaults]
-ansible_managed = Ansible managed: {file} modified on %Y-%m-%d by {uid} on {host}
-
+ansible_managed = Ansible managed: {file} modified by {uid} on {host}
 # additional paths to search for roles in, colon separated
 roles_path    = ../
 
+[ssh_connection]
+scp_if_ssh = True

--- a/templates/limits.conf.j2
+++ b/templates/limits.conf.j2
@@ -1,3 +1,3 @@
-# {{ansible_managed}}
+# {{ ansible_managed | comment }}
 # Prevent core dumps for all users. These are usually only needed by developers and may contain sensitive information.
 * hard core 0

--- a/templates/modules.j2
+++ b/templates/modules.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 # This file contains the names of kernel modules that should be loaded at boot time, one per line. Lines beginning with "#" are ignored.
 #
 # A list of all available kernel modules kann be found with `find /lib/modules/$(uname -r)/kernel/`

--- a/templates/profile.conf.j2
+++ b/templates/profile.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 
 # Disable core dumps via soft limits for all users. Compliance to this setting is voluntary and can be modified by users up to a hard limit. This setting is a sane default.
 ulimit -S -c 0 > /dev/null 2>&1

--- a/templates/rhel_libuser.conf.j2
+++ b/templates/rhel_libuser.conf.j2
@@ -1,6 +1,6 @@
 # See libuser.conf(5) for more information.
 
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 
 # Do not modify the default module list if you care about unattended calls
 # to programs (i.e., scripts) working!

--- a/templates/rhel_sysconfig_init.j2
+++ b/templates/rhel_sysconfig_init.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 
 # color => new RH6.0 bootup
 # verbose => old-style bootup

--- a/templates/rhel_system_auth.j2
+++ b/templates/rhel_system_auth.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 #---
 
 #%PAM-1.0

--- a/templates/securetty.j2
+++ b/templates/securetty.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | comment }}
 
 
 # A list of TTYs, from which root can log in


### PR DESCRIPTION
**ansible.cfg**
- using `%Y-%m-%d` in `ansible_managed` message is not recommended
as deploying from a new git checkout will change the `ansible_managed`
string in the template and Ansible will report the template file as changed
(see http://docs.ansible.com/ansible/intro_configuration.html#ansible-managed )
- add `scp_if_ssh` in ansible.cfg

**comment filter**
- multiline {{ansible_managed}} strings do not get properly commented
    without the comment filter (see
    http://docs.ansible.com/ansible/playbooks_filters.html#comment-filter )