### PR TITLE
Remove deprecated include for static tasks and use instead import_tasks fix #131

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,41 +3,41 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- include: limits.yml
+- import_tasks: limits.yml
   tags: limits
 
-- include: login_defs.yml
+- import_tasks: login_defs.yml
   tags: login_defs
 
-- include: minimize_access.yml
+- import_tasks: minimize_access.yml
   tags: minimize_acces
 
-- include: pam.yml
+- import_tasks: pam.yml
   tags: pam
 
-- include: profile.yml
+- import_tasks: profile.yml
   tags: profile
 
-- include: securetty.yml
+- import_tasks: securetty.yml
   tags: securetty
 
-- include: suid_sgid.yml
+- import_tasks: suid_sgid.yml
   when: os_security_suid_sgid_enforce
   tags: suid_sgid
 
-- include: sysctl.yml
+- import_tasks: sysctl.yml
   tags: sysctl
 
-- include: user_accounts.yml
+- import_tasks: user_accounts.yml
   tags: user_accounts
 
-- include: rhosts.yml
+- import_tasks: rhosts.yml
   tags: rhosts
 
-- include: yum.yml
+- import_tasks: yum.yml
   when: ansible_os_family == 'RedHat'
   tags: yum
 
-- include: apt.yml
+- import_tasks: apt.yml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
   tags: apt


### PR DESCRIPTION
This PR removes the warning messages given by ansible 2.4.0 regarding the deprecation of the "include:" directive and uses the recommended new directive to include static tasks "import_tasks". It fixes #131 