### PR TITLE
Remove rsync from package blacklist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ os_security_suid_sgid_remove_from_unknown: false
 
 # remove packages with known issues
 os_security_packages_clean: true
-os_security_packages_list: ['xinetd','inetd','ypserv','telnet-server','rsh-server','rsync', 'prelink']
+os_security_packages_list: ['xinetd','inetd','ypserv','telnet-server','rsh-server', 'prelink']
 
 # Allow interactive startup (rhel, centos)
 os_security_init_prompt: true


### PR DESCRIPTION
rsync was erroneously added to `os_security_packages_list` variable,
meaning it was uninstalled as a "package with known issues".

Fixes #141