### PR TITLE
Removal of core dump hardening configuration if core dumps are allowed

### DIFF
--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -12,7 +12,7 @@
   - name: create aditional limits config file -> 10.hardcore.conf | sysctl-31a, sysctl-31b
     pam_limits:
       dest: '/etc/security/limits.d/10.hardcore.conf'
-      domain: *
+      domain: '*'
       limit_type: hard
       limit_item: core
       value: 0

--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -1,19 +1,35 @@
 ---
 
-- name: create limits.d-directory if it does not exist | sysctl-31a, sysctl-31b
-  file:
-    path: '/etc/security/limits.d'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-    state: 'directory'
-  when: 'os_security_kernel_enable_core_dump'
+- block:
+  - name: create limits.d-directory if it does not exist | sysctl-31a, sysctl-31b
+    file:
+      path: '/etc/security/limits.d'
+      owner: 'root'
+      group: 'root'
+      mode: '0755'
+      state: 'directory'
+      
+  - name: create aditional limits config file -> 10.hardcore.conf | sysctl-31a, sysctl-31b
+    pam_limits:
+      dest: '/etc/security/limits.d/10.hardcore.conf'
+      domain: *
+      limit_type: hard
+      limit_item: core
+      value: 0
+      comment: Prevent core dumps for all users. These are usually only needed by developers and may contain sensitive information
+      
+  - name: set 10.hardcore.conf perms to 0400 and root ownership
+    file:
+      path: /etc/security/limits.d/10.hardcore.conf
+      owner: 'root'
+      group: 'root'
+      mode: '0440'
+  
+  when: 'not os_security_kernel_enable_core_dump'
 
-- name: create sane limits.conf | sysctl-31a, sysctl-31b
-  template:
-    src: 'limits.conf.j2'
-    dest: '/etc/security/limits.d/10.hardcore.conf'
-    owner: 'root'
-    group: 'root'
-    mode: '0440'
+- name: remove 10.hardcore.conf config file
+  file:
+    path: /etc/security/limits.d/10.hardcore.conf
+    state: absent
+
   when: 'os_security_kernel_enable_core_dump'

--- a/tasks/profile.yml
+++ b/tasks/profile.yml
@@ -9,7 +9,7 @@
   when: not os_security_kernel_enable_core_dump
   
 - name: remove pinerolo_profile.sh from profile.d
-    file:
-      path: /etc/profile.d/pinerolo_profile.sh
-      state: absent
+  file:
+    path: /etc/profile.d/pinerolo_profile.sh
+    state: absent
   when: os_security_kernel_enable_core_dump

--- a/tasks/profile.yml
+++ b/tasks/profile.yml
@@ -1,5 +1,5 @@
 ---
-- name: create profile.conf
+- name: add pinerolo_profile.sh to profile.d
   template:
     src: 'profile.conf.j2'
     dest: '/etc/profile.d/pinerolo_profile.sh'
@@ -7,3 +7,9 @@
     group: 'root'
     mode: '0750'
   when: not os_security_kernel_enable_core_dump
+  
+- name: remove pinerolo_profile.sh from profile.d
+    file:
+      path: /etc/profile.d/pinerolo_profile.sh
+      state: absent
+  when: os_security_kernel_enable_core_dump

--- a/templates/limits.conf.j2
+++ b/templates/limits.conf.j2
@@ -1,3 +1,0 @@
-# {{ ansible_managed | comment }}
-# Prevent core dumps for all users. These are usually only needed by developers and may contain sensitive information.
-* hard core 0


### PR DESCRIPTION
Implemented changes proposed in issue https://github.com/dev-sec/ansible-os-hardening/issues/129  and some other fixes.  
* Grouped tasks with same conditional inside a block and mantained the `create limits.d-directory if it does not exist` task because `pam_limits` module doesn't work if the `dest` parameters has a path with a non-existent directory (https://github.com/ansible/ansible/blob/stable-2.4/lib/ansible/modules/system/pam_limits.py#L171-L180)
* Deleted `/etc/security/limits.d/10.hardcore.conf` and `/etc/profile.d/pinerolo_profile.sh` when variable `os_security_kernel_enable_core_dump` is **True**
* Fixed this when clause (https://github.com/dev-sec/ansible-os-hardening/blob/master/tasks/limits.yml) the condition should be negated, see:  
  * https://github.com/dev-sec/puppet-os-hardening/pull/91/files
  * https://github.com/dev-sec/ansible-os-hardening/blob/3cb86a6202934ae62a09426efc35497e760dd08a/tasks/profile.yml#L9