### PR TITLE
Prevent disabling of filesystems via whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ We disable the following filesystems, because they're most likely not used:
  * "udf"
  * "vfat"
 
+To prevent some of the filesystems from being disabled, add them to the `os_filesystem_whitelist` variable.
+
 ## Example Playbook
 
     - hosts: localhost

--- a/default.yml
+++ b/default.yml
@@ -18,6 +18,7 @@
     os_auth_allow_homeless: true
     os_security_suid_sgid_blacklist: ['/bin/umount']
     os_security_suid_sgid_whitelist: ['/usr/bin/rlogin']
+    os_filesystem_whitelist: ['vfat']
     sysctl_config:
       net.ipv4.ip_forward: 0
       net.ipv6.conf.all.forwarding: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,3 +194,5 @@ os_unused_filesystems:
   - "udf"
   - "vfat"
 
+# whitelist for used filesystems
+os_filesystem_whitelist: []

--- a/templates/modprobe.j2
+++ b/templates/modprobe.j2
@@ -1,5 +1,5 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
 
-{% for fs in os_unused_filesystems %}
+{% for fs in os_unused_filesystems | difference(os_filesystem_whitelist) %}
 install {{fs}} /bin/true
 {% endfor %}


### PR DESCRIPTION
There seems to be no way to prevent disabling specific file systems other than copying and modifying the default list. Entries in the newly create whitelist are removed from the list of file systems to disable.