### PR TITLE
Don't create home for system accounts

### DIFF
--- a/tasks/user_accounts.yml
+++ b/tasks/user_accounts.yml
@@ -40,5 +40,6 @@
     name: '{{ item }}'
     shell: '{{ os_nologin_shell_path }}'
     password: '*'
+    createhome: False
   with_flattened:
     - '{{ sys_accs_cond | default([]) | difference(os_ignore_users) | list }}'


### PR DESCRIPTION
Fixes users `irc` and `systemd-resolve` being changed after reboot,
as their home directory is in `/run`.

Won't create `/home/{syslog,ntp}` any longer (Ubuntu).