### PR TITLE
move defaults to os-specific vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ env:
     version: latest
     init: /sbin/init
 
-  - distro: oracle7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    version: latest
+# oracle 7 does not support ansible 2.4 yet
+# check oracle-epel if it is supported
+# http://yum.oracle.com/repo/OracleLinux/OL7/developer_EPEL/x86_64/index.html
+#  - distro: oracle7
+#    init: /usr/lib/systemd/systemd
+#    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+#    version: latest
 
   - distro: ubuntu1604
     version: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 os_desktop_enable: false
 os_env_extra_user_paths: []
-os_env_umask: '027'
 os_auth_pw_max_age: 60
 os_auth_pw_min_age: 7 # discourage password cycling
 os_auth_retries: 5
@@ -11,12 +10,6 @@ os_auth_pam_passwdqc_enable: true
 os_auth_pam_passwdqc_options: 'min=disabled,disabled,16,12,8' # used in RHEL6
 os_auth_pam_pwquality_options: 'try_first_pass retry=3 type=' # used in RHEL7
 os_auth_root_ttys: [console, tty1, tty2, tty3, tty4, tty5, tty6]
-os_auth_uid_min: 1000
-os_auth_gid_min: 1000
-os_auth_sys_uid_min: 100
-os_auth_sys_uid_max: 999
-os_auth_sys_gid_min: 100
-os_auth_sys_gid_max: 999
 
 os_chfn_restrict: ''
 # may contain: change_user

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,7 +8,7 @@ os_nologin_shell_path: '/usr/sbin/nologin'
 modprobe_package: 'kmod'
 
 # Different distros use different standards for /etc/shadow perms, e.g.
-# RHEL derivatives use root:root 0600, whereas Debian-based use root:shadow 0640.
+# RHEL derivatives use root:root 0000, whereas Debian-based use root:shadow 0640.
 # You must provide key/value pairs for owner, group, and mode if overriding.
 os_shadow_perms:
   owner: root
@@ -19,3 +19,12 @@ os_passwd_perms:
   owner: root
   group: root
   mode: '0644'
+
+os_env_umask: '027'
+
+os_auth_uid_min: 1000
+os_auth_gid_min: 1000
+os_auth_sys_uid_min: 100
+os_auth_sys_uid_max: 999
+os_auth_sys_gid_min: 100
+os_auth_sys_gid_max: 999

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -4,14 +4,23 @@ os_packages_pam_cracklib:  'pam_cracklib'
 os_nologin_shell_path: '/sbin/nologin'
 
 # Different distros use different standards for /etc/shadow perms, e.g.
-# RHEL derivatives use root:root 0600, whereas Debian-based use root:shadow 0640.
+# RHEL derivatives use root:root 0000, whereas Debian-based use root:shadow 0640.
 # You must provide key/value pairs for owner, group, and mode if overriding.
 os_shadow_perms:
   owner: root
   group: root
-  mode: '0600'
+  mode: '0000'
 
 os_passwd_perms:
   owner: root
   group: root
   mode: '0644'
+
+os_env_umask: '077'
+
+os_auth_uid_min: 1000
+os_auth_gid_min: 1000
+os_auth_sys_uid_min: 201
+os_auth_sys_uid_max: 999
+os_auth_sys_gid_min: 201
+os_auth_sys_gid_max: 999

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,14 +8,23 @@ os_packages_pam_cracklib: 'pam_cracklib'
 os_nologin_shell_path: '/sbin/nologin'
 
 # Different distros use different standards for /etc/shadow perms, e.g.
-# RHEL derivatives use root:root 0600, whereas Debian-based use root:shadow 0640.
+# RHEL derivatives use root:root 0000, whereas Debian-based use root:shadow 0640.
 # You must provide key/value pairs for owner, group, and mode if overriding.
 os_shadow_perms:
   owner: root
   group: root
-  mode: '0600'
+  mode: '0000'
 
 os_passwd_perms:
   owner: root
   group: root
   mode: '0644'
+
+os_env_umask: '077'
+
+os_auth_uid_min: 1000
+os_auth_gid_min: 1000
+os_auth_sys_uid_min: 201
+os_auth_sys_uid_max: 999
+os_auth_sys_gid_min: 201
+os_auth_sys_gid_max: 999


### PR DESCRIPTION
This way they can be configured seperately to reflect the changes in the baseline from here: https://github.com/dev-sec/linux-baseline/pull/82

Fixes #155 

The failed travis test in oracle 7 is due to the fact that oracle 7 does not provide ansible 2.4 yet, so it can be ignored.