### PR TITLE
Fix core dump config file creation when core dumps are disabled

### DIFF
--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -31,12 +31,4 @@
   file:
     path: /etc/security/limits.d/10.hardcore.conf
     state: absent
-
-- name: create sane limits.conf | sysctl-31a, sysctl-31b
-  template:
-    src: 'etc/security/limits.d/limits.conf.j2'
-    dest: '/etc/security/limits.d/10.hardcore.conf'
-    owner: 'root'
-    group: 'root'
-    mode: '0440'
   when: 'os_security_kernel_enable_core_dump'

--- a/templates/etc/security/limits.d/limits.conf.j2
+++ b/templates/etc/security/limits.d/limits.conf.j2
@@ -1,3 +1,0 @@
-# {{ ansible_managed | comment }}
-# Prevent core dumps for all users. These are usually only needed by developers and may contain sensitive information.
-* hard core 0

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -12,7 +12,7 @@
       shell: "rm -f /usr/bin/zzz && ln -s /usr/bin /usr/bin/zzz"
   vars:
     os_security_users_allow: change_user
-    os_security_kernel_enable_core_dump: false
+    os_security_kernel_enable_core_dump: true
     os_security_suid_sgid_remove_from_unknown: true
     os_auth_pam_passwdqc_enable: false
     os_desktop_enable: true


### PR DESCRIPTION
It seems that something went wrong when PR #146 was merged to master.

When variable `os_security_kernel_enable_core_dump` is set to `false` the core dump configuration file `/etc/security/limits.d/10.hardcore.conf` will always be removed by the following task:

https://github.com/dev-sec/ansible-os-hardening/blob/30aa3fef3fb47c620369b617a78b0644b69e0082/tasks/limits.yml#L30

In addition, if `os_security_kernel_enable_core_dump` is set to `true`, a core dump config file will be created by mistake:
https://github.com/dev-sec/ansible-os-hardening/blob/30aa3fef3fb47c620369b617a78b0644b69e0082/tasks/limits.yml#L35