### PR TITLE
do not install passwdqc on amazon linux

### DIFF
--- a/tasks/pam.yml
+++ b/tasks/pam.yml
@@ -68,13 +68,13 @@
   yum:
     name: '{{ os_packages_pam_cracklib }}'
     state: 'absent'
-  when: ((ansible_os_family == 'RedHat' and ansible_distribution_version < '7') or ansible_distribution == 'Amazon') and os_auth_pam_passwdqc_enable
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version < '7' and not ansible_distribution == 'Amazon') and os_auth_pam_passwdqc_enable
 
 - name: install the package for strong password checking
   yum:
     name: '{{ os_packages_pam_passwdqc }}'
     state: 'present'
-  when: ((ansible_os_family == 'RedHat' and ansible_distribution_version < '7') or ansible_distribution == 'Amazon') and os_auth_pam_passwdqc_enable
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version < '7' and not ansible_distribution == 'Amazon') and os_auth_pam_passwdqc_enable
 
 - name: remove passwdqc
   yum:


### PR DESCRIPTION
This package does not exist on amazon linux 2. Instead libpwquality is used (like on RHEL7).