### PR TITLE
add /usr/bin/su to suid_guid whitelist

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -43,6 +43,7 @@ os_security_suid_sgid_system_whitelist:
   - '/bin/mount'
   - '/bin/ping'
   - '/bin/su'
+  - '/usr/bin/su'
   - '/bin/umount'
   - '/sbin/pam_timestamp_check'
   - '/sbin/unix_chkpwd'


### PR DESCRIPTION
This should fix issue #140 
Removing the SUID bit from /usr/bin/su breaks it

Signed-off-by: Christian Colic <c@ccolic.ch>