### PR TITLE
Pass package list directly to apt and yum modules without using with_items loop

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,8 +1,6 @@
 ---
 - name: remove deprecated or insecure packages | package-01 - package-09
   apt:
-    name: '{{ item }}'
+    name: '{{ os_security_packages_list }}'
     state: 'absent'
-  with_items:
-    - '{{ os_security_packages_list }}'
   when: 'os_security_packages_clean'

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -40,8 +40,6 @@
 
 - name: remove deprecated or insecure packages | package-01 - package-09
   yum:
-    name: '{{ item }}'
+    name: '{{ os_security_packages_list }}'
     state: 'absent'
-  with_items:
-    - '{{ os_security_packages_list }}'
   when: os_security_packages_clean


### PR DESCRIPTION
Invoking "`apt`" or "`yum`" only once while using a loop via squash_actions is deprecated. This pull request
removes the `with_items` loops to prevent the deprecation warning.