### PR TITLE
do not install the auditd package when it s disabled

### DIFF
--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -4,6 +4,7 @@
   package:
     name: '{{ auditd_package }}'
     state: 'present'
+  when: os_auditd_enabled
 
 - name: configure auditd | package-08
   template:
@@ -12,3 +13,4 @@
     owner: 'root'
     group: 'root'
     mode: '0640'
+  when: os_auditd_enabled


### PR DESCRIPTION
When passing `os_auditd_enabled: false` to the v5.0.0 of this role, it still wanted to install the `auditd` package.

This PR intends to prevent that from happening