### PR TITLE
Added fedora support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
 
+  - distro: fedora
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
   - distro: oracle6
     version: latest
     init: /sbin/init

--- a/tasks/pam.yml
+++ b/tasks/pam.yml
@@ -71,14 +71,14 @@
   yum:
     name: '{{ os_packages_pam_cracklib }}'
     state: 'absent'
-  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | int < 7 and not ansible_distribution == 'Amazon')
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '<') and not ansible_distribution == 'Amazon')
         and os_auth_pam_passwdqc_enable
 
 - name: install the package for strong password checking
   yum:
     name: '{{ os_packages_pam_passwdqc }}'
     state: 'present'
-  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | int < 7 and not ansible_distribution == 'Amazon')
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '<') and not ansible_distribution == 'Amazon')
         and os_auth_pam_passwdqc_enable
 
 - name: remove passwdqc

--- a/tasks/pam.yml
+++ b/tasks/pam.yml
@@ -71,14 +71,14 @@
   yum:
     name: '{{ os_packages_pam_cracklib }}'
     state: 'absent'
-  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '<') and not ansible_distribution == 'Amazon')
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version is version_compare('7', '<') and not ansible_distribution == 'Amazon')
         and os_auth_pam_passwdqc_enable
 
 - name: install the package for strong password checking
   yum:
     name: '{{ os_packages_pam_passwdqc }}'
     state: 'present'
-  when: (ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '<') and not ansible_distribution == 'Amazon')
+  when: (ansible_os_family == 'RedHat' and ansible_distribution_version is version_compare('7', '<') and not ansible_distribution == 'Amazon')
         and os_auth_pam_passwdqc_enable
 
 - name: remove passwdqc

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -61,7 +61,7 @@
     ignoreerrors: yes
   with_dict: '{{ sysctl_rhel_config }}'
   when: ((ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'CentOS') and
-        ansible_distribution_major_version | version_compare('7', '<')) or ansible_distribution == 'Amazon'
+        ansible_distribution_major_version is version_compare('7', '<')) or ansible_distribution == 'Amazon'
 
 - name: Apply ufw defaults
   template:

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -61,7 +61,7 @@
     ignoreerrors: yes
   with_dict: '{{ sysctl_rhel_config }}'
   when: ((ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'CentOS') and
-        ansible_distribution_major_version | int < 7) or ansible_distribution == 'Amazon'
+        ansible_distribution_major_version | version_compare('7', '<')) or ansible_distribution == 'Amazon'
 
 - name: Apply ufw defaults
   template:

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -14,14 +14,13 @@
   changed_when: False
   register: yum_repos
 
-- name: check if rhnplugin.conf exists
-  stat:
-    path: '/etc/yum/pluginconf.d/rhnplugin.conf'
-  register: rhnplugin_file
-
   # for the 'default([])' see here:
   # https://github.com/dev-sec/ansible-os-hardening/issues/99 and
   # https://stackoverflow.com/questions/37067827/ansible-deprecation-warning-for-undefined-variable-despite-when-clause
+  #
+  # failed_when is needed because by default replace module will fail if the file doesn't exists.
+  # status.rc is only defined if an error accrued and only error code (rc) 257 will be ignored.
+  # All other errors will still be raised.
 - name: activate gpg-check for yum-repos
   replace:
     dest: '{{ item }}'
@@ -33,13 +32,7 @@
     - '/etc/yum.conf'
     - '/etc/dnf/dnf.conf'
     - '{{ yum_repos.stdout_lines| default([]) }}'
-
-- name: activate gpg-check for yum rhn if it exists
-  replace:
-    dest: '/etc/yum/pluginconf.d/rhnplugin.conf'
-    regexp: '^\s*gpgcheck: 0'
-    replace: 'gpgcheck: 1'
-  when: rhnplugin_file.stat.exists
+    - '/etc/yum/pluginconf.d/rhnplugin.conf'
 
 - name: remove deprecated or insecure packages | package-01 - package-09
   yum:

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -21,7 +21,7 @@
   # failed_when is needed because by default replace module will fail if the file doesn't exists.
   # status.rc is only defined if an error accrued and only error code (rc) 257 will be ignored.
   # All other errors will still be raised.
-- name: activate gpg-check for yum-repos
+- name: activate gpg-check for config files
   replace:
     dest: '{{ item }}'
     regexp: '^\s*gpgcheck: 0'

--- a/templates/etc/pam.d/rhel_system_auth.j2
+++ b/templates/etc/pam.d/rhel_system_auth.j2
@@ -18,7 +18,7 @@ account     sufficient    pam_succeed_if.so uid < 500 quiet
 account     required      pam_permit.so
 
 {% if (os_auth_pam_passwdqc_enable|bool) %}
-  {%- if ((ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '>=')) or ansible_distribution == 'Amazon') %}
+  {%- if ((ansible_os_family == 'RedHat' and ansible_distribution_version is version_compare('7', '>=')) or ansible_distribution == 'Amazon') %}
 password    required      pam_pwquality.so {{ os_auth_pam_pwquality_options }}
   {%- else %}
 password    requisite     pam_passwdqc.so {{ os_auth_pam_passwdqc_options }}

--- a/templates/etc/pam.d/rhel_system_auth.j2
+++ b/templates/etc/pam.d/rhel_system_auth.j2
@@ -18,7 +18,7 @@ account     sufficient    pam_succeed_if.so uid < 500 quiet
 account     required      pam_permit.so
 
 {% if (os_auth_pam_passwdqc_enable|bool) %}
-  {%- if ((ansible_os_family == 'RedHat' and ansible_distribution_version | int >= 7) or ansible_distribution == 'Amazon') %}
+  {%- if ((ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('7', '>=')) or ansible_distribution == 'Amazon') %}
 password    required      pam_pwquality.so {{ os_auth_pam_pwquality_options }}
   {%- else %}
 password    requisite     pam_passwdqc.so {{ os_auth_pam_passwdqc_options }}


### PR DESCRIPTION
Added to version check "|int" so jinja2 will do proper int comparison
Added failed_when to "activate gpg-check for yum-repos" because yum.conf is replaced in newer fedora versions. Task only fails if error is not "file doesn't exists"
Signed-off-by: Jonas Wrede <jonwrede@users.noreply.github.com>