### PR TITLE
Test Kitchen Vagrant Fixes

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -16,7 +16,7 @@ provisioner:
   require_ruby_for_busser: false
   ansible_verbose: true
   roles_path: ../ansible-os-hardening/
-  playbook: default.yml
+  playbook: tests/test.yml
   http_proxy: <%= ENV['http_proxy'] || nil %>
   https_proxy: <%= ENV['https_proxy'] || nil %>
 


### PR DESCRIPTION
Tests wouldn't run as it was pointing to an incorrect file location. This PR updates the path and allows the tests to run.