### PR TITLE
Update modprobe to 0644

### DIFF
--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -20,4 +20,4 @@
     dest: '/etc/modprobe.d/dev-sec.conf'
     owner: 'root'
     group: 'root'
-    mode: '0640'
+    mode: '0644'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -27,7 +27,7 @@
     os_auth_allow_homeless: true
     os_security_suid_sgid_blacklist: ['/bin/umount']
     os_security_suid_sgid_whitelist: ['/usr/bin/rlogin']
-    os_filesystem_whitelist: ['vfat']
+    os_filesystem_whitelist: []
     sysctl_config:
       net.ipv4.ip_forward: 0
       net.ipv6.conf.all.forwarding: 0
@@ -66,7 +66,6 @@
       fs.suid_dumpable: 0
       kernel.randomize_va_space: 2
 
-
 - name: wrapper playbook for kitchen testing "ansible-os-hardening"
   hosts: localhost
   vars:
@@ -78,4 +77,3 @@
       when: ansible_os_family == 'Debian'
   roles:
     - ansible-os-hardening
-


### PR DESCRIPTION
This fixes Inspec tests that fail when running on Ubuntu 18.04. The user currently does not have the required privileges needed to read the file. Happy to answer any questions.