### PR TITLE
Changed local var name to a less common one

### DIFF
--- a/tasks/rhosts.yml
+++ b/tasks/rhosts.yml
@@ -3,13 +3,13 @@
   command: "awk -F: '{print $1}' /etc/passwd"
   changed_when: False
   check_mode: False
-  register: users
+  register: users_accounts
 
 - name: delete rhosts-files from system | os-09
   file:
     dest: '~{{ item }}/.rhosts'
     state: 'absent'
-  with_flattened: '{{ users.stdout_lines | default([]) }}'
+  with_flattened: '{{ users_accounts.stdout_lines | default([]) }}'
 
 - name: delete hosts.equiv from system | os-01
   file:
@@ -20,4 +20,4 @@
   file:
     dest: '~{{ item }}/.netrc'
     state: 'absent'
-  with_flattened: '{{ users.stdout_lines | default([]) }}'
+  with_flattened: '{{ users_accounts.stdout_lines | default([]) }}'


### PR DESCRIPTION
"users" is a common var name. This local register overwrite the user's input, effectively breaking roles like weareinteractive.users. Since the "users" var name is more meaningful for a end user usage let's rename the register output to a more technical value.