### PR TITLE
Add test support for debian buster

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -45,6 +45,9 @@ platforms:
 - name: debian-9
   driver_config:
     box: bento/debian-9
+- name: debian-10
+  driver_config:
+    box: bento/debian-10
 - name: amazon
   driver_config:
     box: bento/amazonlinux-2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,14 @@ platforms:
     provision_command:
       - apt install -y systemd-sysv
       - systemctl enable ssh.service
+- name: debian10-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian10-ansible:latest
+    platform: debian
+    run_command: /sbin/init
+    provision_command:
+      - apt install -y systemd-sysv
+      - systemctl enable ssh.service
 - name: amazon-ansible-latest
   driver:
     image: rndmh3ro/docker-amazon-ansible:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,11 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
+  - distro: debian10
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
   - distro: amazon
     init: /lib/systemd/systemd
     version: latest

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
+        - buster
     - name: Amazon
     - name: Fedora
   galaxy_tags:


### PR DESCRIPTION
This PR adds testing support for Debian Buster.  

- [x] Travis builds for debian buster tested successfully
- [x] kitchen ci docker builds with debian buster tested successfully
- [x] kitchen ci vagrant builds with debian buster tested successfully

Closes https://github.com/dev-sec/ansible-os-hardening/issues/233