### PR TITLE
Support configuring SELinux and default to enforcing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -250,3 +250,8 @@ os_hardening_enabled: true
 
 # Set to false to disable installing and configuring auditd.
 os_auditd_enabled: true
+
+# Set the SELinux state, can be either disabled, permissive, or enforcing.
+os_selinux_state: enforcing
+# Set the SELinux polixy.
+os_selinux_policy: targeted

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -58,3 +58,10 @@
 - import_tasks: apt.yml
   when: ansible_facts.distribution == 'Debian' or ansible_facts.distribution == 'Ubuntu'
   tags: apt
+
+- import_tasks: selinux.yml
+  tags: selinux
+  when:
+    - ansible_facts.ansible_selinux is defined
+    - ansible_facts.ansible_selinux
+

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -62,6 +62,4 @@
 - import_tasks: selinux.yml
   tags: selinux
   when:
-    - ansible_facts.ansible_selinux is defined
-    - ansible_facts.ansible_selinux
-
+    - ansible_facts.selinux.status == 'enabled'

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,5 @@
+---
+- name: configure selinux | selinux-01
+  selinux:
+    policy: "{{ os_selinux_policy }}"
+    state: "{{ os_selinux_state }}"


### PR DESCRIPTION
Closes https://github.com/dev-sec/ansible-os-hardening/issues/154

I think this might do the right thing, will checkout the build though. I chose to default to `enforcing` as I don't want the defaults here to actually walk back the configuration that RHEL and friends ship with. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>