### PR TITLE
Fedora - Use new auto ansible_python_interpreter for dnf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
-    ANSIBLE_PYTHON_INTERPRETER: auto
 
   - distro: oracle6
     version: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
+    ANSIBLE_PYTHON_INTERPRETER: auto
 
   - distro: oracle6
     version: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,9 @@ script:
   # Run container in detached state.
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-os-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
 
+  # Output Ansible version from docker image
+  - 'docker exec "$(cat ${container_id})" ansible-playbook --version'
+
    # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-os-hardening/tests/test.yml --diff --skip-tags "sysctl"'
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -63,8 +63,7 @@
       net.ipv6.conf.default.accept_ra_rtr_pref: 0
       net.ipv6.conf.default.accept_ra_pinfo: 0
       net.ipv6.conf.default.accept_ra_defrtr: 0
-      net.ipv6.conf.default.
-      conf: 0
+      net.ipv6.conf.default.conf: 0
       net.ipv6.conf.default.dad_transmits: 0
       net.ipv6.conf.default.max_addresses: 1
       kernel.sysrq: 0

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -18,6 +18,7 @@
     - name: create recursing symlink to test minimize access
       shell: "rm -f /usr/bin/zzz && ln -s /usr/bin /usr/bin/zzz"
   vars:
+    ansible_python_interpreter: auto
     os_security_users_allow: change_user
     os_security_kernel_enable_core_dump: true
     os_security_suid_sgid_remove_from_unknown: true
@@ -69,7 +70,8 @@
 - name: wrapper playbook for kitchen testing "ansible-os-hardening"
   hosts: localhost
   vars:
-    - os_auditd_enabled: false
+    os_auditd_enabled: false
+    ansible_python_interpreter: auto
   pre_tasks:
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,10 +4,11 @@
   roles:
     - ansible-os-hardening
   pre_tasks:
-    - name: set ansible_python_interpreter to auto on systems with ansible 2.8
+    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
       set_fact:
-        ansible_python_interpreter: "auto"
-      when: ansible_version.full is version('2.8', '>')
+        ansible_python_interpreter: "/usr/bin/python3"
+      when: ansible_facts.distribution == 'Fedora'
+
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
         update_cache: yes
@@ -75,10 +76,11 @@
   vars:
     os_auditd_enabled: false
   pre_tasks:
-    - name: set ansible_python_interpreter to auto on systems with ansible 2.8
+    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
       set_fact:
-        ansible_python_interpreter: "auto"
-      when: ansible_version.full is version('2.8', '>')
+        ansible_python_interpreter: "/usr/bin/python3"
+      when: ansible_facts.distribution == 'Fedora'
+
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
         update_cache: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -63,7 +63,8 @@
       net.ipv6.conf.default.accept_ra_rtr_pref: 0
       net.ipv6.conf.default.accept_ra_pinfo: 0
       net.ipv6.conf.default.accept_ra_defrtr: 0
-      net.ipv6.conf.default.autoconf: 0
+      net.ipv6.conf.default.
+      conf: 0
       net.ipv6.conf.default.dad_transmits: 0
       net.ipv6.conf.default.max_addresses: 1
       kernel.sysrq: 0
@@ -74,8 +75,11 @@
   hosts: localhost
   vars:
     os_auditd_enabled: false
-    ansible_python_interpreter: auto
   pre_tasks:
+     - name: set ansible_python_interpreter to auto on systems with ansible 2.8
+      set_fact:
+        ansible_python_interpreter: "auto"
+      when: ansible_version.full is version('2.8', '>')
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
         update_cache: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -75,7 +75,7 @@
   vars:
     os_auditd_enabled: false
   pre_tasks:
-     - name: set ansible_python_interpreter to auto on systems with ansible 2.8
+    - name: set ansible_python_interpreter to auto on systems with ansible 2.8
       set_fact:
         ansible_python_interpreter: "auto"
       when: ansible_version.full is version('2.8', '>')

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,10 @@
   roles:
     - ansible-os-hardening
   pre_tasks:
+    - name: set ansible_python_interpreter to auto on systems with ansible 2.8
+      set_fact:
+        ansible_python_interpreter: "auto"
+      when: ansible_version.full is version('2.8', '>')
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
         update_cache: yes
@@ -18,7 +22,6 @@
     - name: create recursing symlink to test minimize access
       shell: "rm -f /usr/bin/zzz && ln -s /usr/bin /usr/bin/zzz"
   vars:
-    ansible_python_interpreter: auto
     os_security_users_allow: change_user
     os_security_kernel_enable_core_dump: true
     os_security_suid_sgid_remove_from_unknown: true


### PR DESCRIPTION
Docs: https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html

Noticed this in https://travis-ci.org/dev-sec/ansible-os-hardening/jobs/597153020, looks like Ansible can't find `python2-dnf` and thus Fedora is angry. Some digging found https://github.com/ansible/ansible/issues/49362#issuecomment-513500588 which makes sense to me. 

This is a quick attempt to configure `ansible_python_interpreter` to use the newer `auto` setting, which should be the new default in 2.12 just for Fedora. 

Opening this to verify the TravisCI build passes. If so, good to merge! 