### PR TITLE
Add exception in sysctl task

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -49,6 +49,7 @@
     reload: yes
     ignoreerrors: yes
   with_dict: '{{ sysctl_config }}'
+  when: ansible_virtualization_type != 'docker' and ansible_virtualization_type != 'openvz'
 
 - name: Change various sysctl-settings on rhel6-hosts or older, look at the sysctl-vars file for documentation
   sysctl:


### PR DESCRIPTION
No need apply sysctl in docker and openvz containers. I think that it not right. Because not all sysctls are namespaced. Docker does not support changing sysctls inside of a container that also modify the host system. As the kernel evolves we expect to see more sysctls become namespaced.

But when I run test on os-debian9-ansible-latest for example, I got many failed sysctl-* tests. Because only_if don't work for me (https://github.com/dev-sec/linux-baseline/blob/master/controls/sysctl_spec.rb#L23)