### PR TITLE
Standardize the var ordering

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,12 +1,9 @@
+---
+
 os_packages_pam_ccreds: 'libpam-ccreds'
 os_packages_pam_passwdqc: 'libpam-passwdqc'
 os_packages_pam_cracklib: 'libpam-cracklib'
-passwdqc_path: '/usr/share/pam-configs/passwdqc'
-tally2_path: '/usr/share/pam-configs/tally2'
 os_nologin_shell_path: '/usr/sbin/nologin'
-
-auditd_package: 'auditd'
-modprobe_package: 'kmod'
 
 # Different distros use different standards for /etc/shadow perms, e.g.
 # RHEL derivatives use root:root 0000, whereas Debian-based use root:shadow 0640.
@@ -29,3 +26,9 @@ os_auth_sys_uid_min: 100
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 999
+
+modprobe_package: 'kmod'
+auditd_package: 'auditd'
+
+tally2_path: '/usr/share/pam-configs/tally2'
+passwdqc_path: '/usr/share/pam-configs/passwdqc'

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,8 +1,5 @@
 ---
 
-modprobe_package: 'module-init-tools'
-auditd_package: 'audit'
-
 os_packages_pam_ccreds: 'pam_ccreds'
 os_packages_pam_passwdqc: 'pam_passwdqc'
 os_packages_pam_cracklib: 'pam_cracklib'
@@ -29,3 +26,6 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+
+modprobe_package: 'module-init-tools'
+auditd_package: 'audit'

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,6 +1,8 @@
-os_packages_pam_ccreds:  'pam_ccreds'
-os_packages_pam_passwdqc:  'pam_passwdqc'
-os_packages_pam_cracklib:  'pam_cracklib'
+---
+
+os_packages_pam_ccreds: 'pam_ccreds'
+os_packages_pam_passwdqc: 'pam_passwdqc'
+os_packages_pam_cracklib: 'pam_cracklib'
 os_nologin_shell_path: '/sbin/nologin'
 
 # Different distros use different standards for /etc/shadow perms, e.g.

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,8 +1,5 @@
 ---
 
-modprobe_package: 'module-init-tools'
-auditd_package: 'audit'
-
 os_packages_pam_ccreds: 'pam_ccreds'
 os_packages_pam_passwdqc: 'pam_passwdqc'
 os_packages_pam_cracklib: 'pam_cracklib'
@@ -29,3 +26,6 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+
+modprobe_package: 'module-init-tools'
+auditd_package: 'audit'


### PR DESCRIPTION
Now the vars for these OS are in the same order. This makes it much 
easier to see the differences