### PR TITLE
Addressing issue #255:

### DIFF
--- a/tasks/user_accounts.yml
+++ b/tasks/user_accounts.yml
@@ -10,17 +10,22 @@
 - name: calculate UID_MAX from UID_MIN by substracting 1
   set_fact:
     uid_max: '{{ uid_min.stdout | int - 1 }}'
-  when: uid_min is defined
+  when:
+    - uid_min.stdout is not search(logindefs_missing_msg)
 
 - name: set UID_MAX on Debian-systems if no login.defs exist
   set_fact:
     uid_max: '999'
-  when: ansible_facts.os_family == 'Debian' and not uid_min
+  when:
+    - ansible_facts.os_family == 'Debian'
+    - uid_min.stdout is search(logindefs_missing_msg)
 
 - name: set UID_MAX on other systems if no login.defs exist
   set_fact:
     uid_max: '499'
-  when: not uid_min
+  when:
+    - ansible_facts.os_family != 'Debian'
+    - uid_min.stdout is search(logindefs_missing_msg)
 
 - name: get all system accounts
   command: awk -F'':'' '{ if ( $3 <= {{ uid_max|quote }} ) print $1}' /etc/passwd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -109,3 +109,6 @@ os_security_suid_sgid_system_whitelist:
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
+
+# set message for login.defs missing test
+logindefs_missing_msg: 'login.defs does not exist'


### PR DESCRIPTION
- Added conditional logic to test the uid_min data structure stdout
  for the existence, or non-existence, of a string indicating that
  the login.defs task was skipped due to login.defs not existing.
- Added a condition to the task for setting uid_max for 'other' systems
  to ensure that they are NOT Debian.
- Added a global variable 'logindefs_missing_msg' to allow for the
  tested string to be configured globally in case it changes.