### PR TITLE
Addressing issue #255

### DIFF
--- a/tasks/user_accounts.yml
+++ b/tasks/user_accounts.yml
@@ -10,17 +10,19 @@
 - name: calculate UID_MAX from UID_MIN by substracting 1
   set_fact:
     uid_max: '{{ uid_min.stdout | int - 1 }}'
-  when: uid_min is defined
+  when: uid_min.stdout|int > 0 
 
 - name: set UID_MAX on Debian-systems if no login.defs exist
   set_fact:
     uid_max: '999'
-  when: ansible_facts.os_family == 'Debian' and not uid_min
+  when:
+    - ansible_facts.os_family == 'Debian'
+    - uid_max is not defined
 
 - name: set UID_MAX on other systems if no login.defs exist
   set_fact:
     uid_max: '499'
-  when: not uid_min
+  when: uid_max is not defined
 
 - name: get all system accounts
   command: awk -F'':'' '{ if ( $3 <= {{ uid_max|quote }} ) print $1}' /etc/passwd


### PR DESCRIPTION
Fixes #255 
- Added logic to pull uid_min from login.defs when it returns an
  integer value greater than 0.
- Add logic so that Debian systems use inherit uid_max=999 when
  a uid_max was not found in login.defs.
- Add logic so that all other systems inherit uid_max=499 only
  when the value was not already found in login.defs or set for
  Debian systems.