### PR TITLE
Add kernel parameter information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ So for example if you want to change the IPv4 traffic forwarding variable to `1`
 
 Alternatively you can change Ansible's [hash-behaviour](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-hash-behaviour) to `merge`, then you only have to overwrite the single hash you need to. But please be aware that changing the hash-behaviour changes it for all your playbooks and is not recommended by Ansible.
 
+## Improving Kernel Audit logging
+
+By default, any process that starts before the `auditd` daemon will have an AUID of `4294967295`. To improve this and provide more accurate logging, it's reccomend to add the kernel boot parameter `audit=1` to you configuration. Without doing this, you will find that your `auditd` logs fail to properly audit all processes. 
+
+For more information, please see this [upstream documentation](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) and your system's boot loader documentation, for how to configure additional kernel parameters. 
+
 ## Local Testing
 
 The preferred way of locally testing the role is to use Docker. You will have to install Docker on your system. See [Get started](https://docs.docker.com/) for a Docker package suitable to for your system.

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ Alternatively you can change Ansible's [hash-behaviour](https://docs.ansible.com
 
 ## Improving Kernel Audit logging
 
-By default, any process that starts before the `auditd` daemon will have an AUID of `4294967295`. To improve this and provide more accurate logging, it's reccomend to add the kernel boot parameter `audit=1` to you configuration. Without doing this, you will find that your `auditd` logs fail to properly audit all processes. 
+By default, any process that starts before the `auditd` daemon will have an AUID of `4294967295`. To improve this and provide more accurate logging, it's recommended to add the kernel boot parameter `audit=1` to you configuration. Without doing this, you will find that your `auditd` logs fail to properly audit all processes. 
 
-For more information, please see this [upstream documentation](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) and your system's boot loader documentation, for how to configure additional kernel parameters. 
+For more information, please see this [upstream documentation](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) and your system's boot loader documentation for how to configure additional kernel parameters. 
 
 ## Local Testing
 


### PR DESCRIPTION
Add initial documentation around configuring audit=1 to reduce the inaccuracies in the auditd logs. 
Closes https://github.com/dev-sec/ansible-os-hardening/issues/253

Signed-off-by: Jared Ledvina <jared@techsmix.net>