### PR TITLE
Make useradd defaults in login.defs dependent on OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -175,17 +175,6 @@ sysctl_config:
 
   kernel.core_uses_pid: 1
 
-  # When an attacker is trying to exploit the local kernel, it is often
-  # helpful to be able to examine where in memory the kernel, modules,
-  # and data structures live. As such, kernel addresses should be treated
-  # as sensitive information.
-  #
-  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
-  # /proc/modules, etc), and this setting can censor the addresses. A value
-  # of "0" allows all users to see the kernel addresses. A value of "1"
-  # limits visibility to the root user, and "2" blocks even the root user.
-  kernel.kptr_restrict: 1
-
   # The PTRACE system is used for debugging.  With it, a single user process
   # can attach to any other dumpable process owned by the same user.  In the
   # case of malicious software, it is possible to use PTRACE to access
@@ -232,6 +221,16 @@ sysctl_config:
   vm.mmap_rnd_bits: 32
   vm.mmap_rnd_compat_bits: 16
 
+  # When an attacker is trying to exploit the local kernel, it is often
+  # helpful to be able to examine where in memory the kernel, modules,
+  # and data structures live. As such, kernel addresses should be treated
+  # as sensitive information.
+  #
+  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
+  # /proc/modules, etc), and this setting can censor the addresses. A value
+  # of "0" allows all users to see the kernel addresses. A value of "1"
+  # limits visibility to the root user, and "2" blocks even the root user.
+  #
   # Some off-the-shelf malware exploit kernel addresses exposed
   # via /proc/kallsyms so by not making these addresses easily available
   # we increase the cost of such attack some what; now such malware has

--- a/templates/etc/audit/auditd.conf.j2
+++ b/templates/etc/audit/auditd.conf.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 log_file = /var/log/audit/audit.log
 log_format = RAW
 log_group = root

--- a/templates/etc/default/ufw.j2
+++ b/templates/etc/default/ufw.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
+
 # /etc/default/ufw
 #
 

--- a/templates/etc/initramfs-tools/modules.j2
+++ b/templates/etc/initramfs-tools/modules.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
+
 # This file contains the names of kernel modules that should be loaded at boot time, one per line. Lines beginning with "#" are ignored.
 #
 # A list of all available kernel modules kann be found with `find /lib/modules/$(uname -r)/kernel/`

--- a/templates/etc/libuser.conf.j2
+++ b/templates/etc/libuser.conf.j2
@@ -1,6 +1,6 @@
-# See libuser.conf(5) for more information.
+{{ ansible_managed | comment }}
 
-# {{ ansible_managed | comment }}
+# See libuser.conf(5) for more information. 
 
 # Do not modify the default module list if you care about unattended calls
 # to programs (i.e., scripts) working!

--- a/templates/etc/login.defs.j2
+++ b/templates/etc/login.defs.j2
@@ -8,6 +8,7 @@
 #
 #-- Modified for Linux.  --marekm
 
+{% if os_useradd_mail_dir is defined %}
 # *REQUIRED for useradd/userdel/usermod*
 #
 # Directory where mailboxes reside, _or_ name of file, relative to the home directory.  If you _do_ define `MAIL_DIR` and `MAIL_FILE`, `MAIL_DIR` takes precedence.
@@ -20,9 +21,14 @@
 #
 # See default PAM configuration files provided for login, su, etc.
 # This is a temporary situation: setting these variables will soon move to `/etc/default/useradd` and the variables will then be no more supported
-MAIL_DIR          /var/mail
-#MAIL_FILE         .mail
+MAIL_DIR          {{ os_useradd_mail_dir }}
+{% endif %}
 
+{% if os_useradd_create_home is defined %}
+# If useradd should create home directories for users by default
+CREATE_HOME	      {{ 'yes' if os_useradd_create_home else 'no' }}
+
+{% endif %}
 # Enable logging and display of `/var/log/faillog` login failure info. This option conflicts with the `pam_tally` PAM module.
 FAILLOG_ENAB      yes
 
@@ -58,7 +64,7 @@ HUSHLOGIN_FILE    .hushlogin
 
 # *REQUIRED*: The default PATH settings, for superuser and normal users. (they are minimal, add the rest in the shell startup files)
 ENV_SUPATH        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV_PATH          PATH=/usr/local/bin:/usr/bin:/bin:{{ os_env_extra_user_paths| join (':') }}
+ENV_PATH          PATH=/usr/local/bin:/usr/bin:/bin:{{ os_env_extra_user_paths | join (':') }}
 
 # Terminal permissions
 # --------------------

--- a/templates/etc/login.defs.j2
+++ b/templates/etc/login.defs.j2
@@ -20,136 +20,136 @@
 #
 # See default PAM configuration files provided for login, su, etc.
 # This is a temporary situation: setting these variables will soon move to `/etc/default/useradd` and the variables will then be no more supported
-MAIL_DIR        /var/mail
-#MAIL_FILE      .mail
+MAIL_DIR          /var/mail
+#MAIL_FILE         .mail
 
 # Enable logging and display of `/var/log/faillog` login failure info. This option conflicts with the `pam_tally` PAM module.
-FAILLOG_ENAB		yes
+FAILLOG_ENAB      yes
 
 # Enable display of unknown usernames when login failures are recorded.
 #
 # *WARNING*: Unknown usernames may become world readable. See #290803 and #298773 for details about how this could become a security concern
-LOG_UNKFAIL_ENAB	no
+LOG_UNKFAIL_ENAB  no
 
 # Enable logging of successful logins
-LOG_OK_LOGINS		yes
+LOG_OK_LOGINS     yes
 
 # Enable "syslog" logging of su activity - in addition to sulog file logging.
-SYSLOG_SU_ENAB		yes
+SYSLOG_SU_ENAB    yes
 
 # Enable "syslog" logging of newgrp and sg.
-SYSLOG_SG_ENAB		yes
+SYSLOG_SG_ENAB    yes
 
 # If defined, all su activity is logged to this file.
-#SULOG_FILE	/var/log/sulog
+#SULOG_FILE        /var/log/sulog
 
 # If defined, file which maps tty line to `TERM` environment parameter. Each line of the file is in a format something like "vt100  tty01".
-#TTYTYPE_FILE	/etc/ttytype
+#TTYTYPE_FILE      /etc/ttytype
 
 # If defined, login failures will be logged here in a utmp format last, when invoked as lastb, will read `/var/log/btmp`, so...
-FTMP_FILE	/var/log/btmp
+FTMP_FILE         /var/log/btmp
 
 # If defined, the command name to display when running "su -".  For # example, if this is defined as "su" then a "ps" will display the command is "-su".  If not defined, then "ps" would display the name of the shell actually being run, e.g. something like "-sh".
-SU_NAME		su
+SU_NAME           su
 
 # If defined, file which inhibits all the usual chatter during the login sequence.  If a full pathname, then hushed mode will be enabled if the user's name or shell are found in the file.  If not a full pathname, then hushed mode will be enabled if the file exists in the user's home directory.
-#HUSHLOGIN_FILE /etc/hushlogins
-HUSHLOGIN_FILE	.hushlogin
+#HUSHLOGIN_FILE    /etc/hushlogins
+HUSHLOGIN_FILE    .hushlogin
 
 # *REQUIRED*: The default PATH settings, for superuser and normal users. (they are minimal, add the rest in the shell startup files)
-ENV_SUPATH	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV_PATH	PATH=/usr/local/bin:/usr/bin:/bin:{{ os_env_extra_user_paths| join (':') }}
+ENV_SUPATH        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV_PATH          PATH=/usr/local/bin:/usr/bin:/bin:{{ os_env_extra_user_paths| join (':') }}
 
 # Terminal permissions
 # --------------------
 
 # Login tty will be assigned this group ownership.
 # If you have a "write" program which is "setgid" to a special group which owns the terminals, define `TTYGROUP` to the group number and `TTYPERM` to `0620`.  Otherwise leave `TTYGROUP` commented out and assign `TTYPERM` to either `622` or `600`.
-TTYGROUP  tty
+TTYGROUP          tty
 
 # Login tty will be set to this permission.
 # In Debian `/usr/bin/bsd-write` or similar programs are setgid tty. However, the default and recommended value for `TTYPERM` is still `0600` to not allow anyone to write to anyone else console or terminal
 # Users can still allow other people to write them by issuing the `mesg y` command.
-TTYPERM   0600
+TTYPERM           0600
 
 # Login conf initializations
 # --------------------------
 
 # Terminal ERASE character ('\010' = backspace). Only used on System V.
-ERASECHAR 0177
+ERASECHAR         0177
 
 # Terminal KILL character ('\025' = CTRL/U). Only used on System V.
-KILLCHAR  025
+KILLCHAR          025
 
 # The default umask value for `pam_umask` and is used by useradd and newusers to set the mode of the new home directories.
 # If `USERGROUPS_ENAB` is set to `yes`, that will modify this `UMASK` default value for private user groups, i. e. the uid is the same as gid, and username is the same as the primary group name: for these, the user permissions will be used as group permissions, e. g. `022` will become `002`.
 # Prefix these values with `0` to get octal, `0x` to get hexadecimal.
 # `022` is the "historical" value in Debian for UMASK
 # `027`, or even `077`, could be considered better for privacy.
-UMASK {{ os_env_umask }}
+UMASK             {{ os_env_umask }}
 
 # Enable setting of the umask group bits to be the same as owner bits (examples: `022` -> `002`, `077` -> `007`) for non-root users, if the uid is the same as gid, and username is the same as the primary group name.
 # If set to yes, userdel will remove the user´s group if it contains no more members, and useradd will create by default a group with the name of the user.
-USERGROUPS_ENAB yes
+USERGROUPS_ENAB   yes
 
 
 # Password aging controls
 # -----------------------
 
 # Maximum number of days a password may be used.
-PASS_MAX_DAYS {{ os_auth_pw_max_age }}
+PASS_MAX_DAYS     {{ os_auth_pw_max_age }}
 
 # Minimum number of days allowed between password changes.
-PASS_MIN_DAYS {{ os_auth_pw_min_age }}
+PASS_MIN_DAYS     {{ os_auth_pw_min_age }}
 
 # Number of days warning given before a password expires.
-PASS_WARN_AGE	7
+PASS_WARN_AGE     7
 
 # Min/max values for automatic uid selection in useradd
-UID_MIN			 {{ os_auth_uid_min }}
-UID_MAX			60000
+UID_MIN           {{ os_auth_uid_min }}
+UID_MAX           60000
 # System accounts
-SYS_UID_MIN		  {{ os_auth_sys_uid_min }}
-SYS_UID_MAX		  {{ os_auth_sys_uid_max }}
+SYS_UID_MIN       {{ os_auth_sys_uid_min }}
+SYS_UID_MAX       {{ os_auth_sys_uid_max }}
 
 # Min/max values for automatic gid selection in groupadd
-GID_MIN			 {{ os_auth_gid_min }}
-GID_MAX			60000
+GID_MIN           {{ os_auth_gid_min }}
+GID_MAX           60000
 # System accounts
-SYS_GID_MIN		  {{ os_auth_sys_gid_min }}
-SYS_GID_MAX		  {{ os_auth_sys_gid_max }}
+SYS_GID_MIN       {{ os_auth_sys_gid_min }}
+SYS_GID_MAX       {{ os_auth_sys_gid_max }}
 
 # Max number of login retries if password is bad. This will most likely be overriden by PAM, since the default pam_unix module has it's own built in of 3 retries. However, this is a safe fallback in case you are using an authentication module that does not enforce PAM_MAXTRIES.
-LOGIN_RETRIES		{{ os_auth_retries }}
+LOGIN_RETRIES     {{ os_auth_retries }}
 
 # Max time in seconds for login
-LOGIN_TIMEOUT		{{ os_auth_timeout }}
+LOGIN_TIMEOUT     {{ os_auth_timeout }}
 
 # Which fields may be changed by regular users using chfn - use any combination of letters "frwh" (full name, room number, work phone, home phone).  If not defined, no changes are allowed.
 # For backward compatibility, "yes" = "rwh" and "no" = "frwh".
 {% if os_chfn_restrict %}
-CHFN_RESTRICT		{{ os_chfn_restrict }}
+CHFN_RESTRICT     {{ os_chfn_restrict }}
 {% endif %}
 # Should login be allowed if we can't cd to the home directory?
-DEFAULT_HOME	{{ 'yes' if os_auth_allow_homeless else 'no' }}
+DEFAULT_HOME      {{ 'yes' if os_auth_allow_homeless else 'no' }}
 
 # If defined, this command is run when removing a user.
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
-#USERDEL_CMD	/usr/sbin/userdel_local
+#USERDEL_CMD       /usr/sbin/userdel_local
 
 # Instead of the real user shell, the program specified by this parameter will be launched, although its visible name (`argv[0]`) will be the shell's. The program may do whatever it wants (logging, additional authentification, banner, ...) before running the actual shell.
-#FAKE_SHELL /bin/fakeshell
+#FAKE_SHELL        /bin/fakeshell
 
 # If defined, either full pathname of a file containing device names or a ":" delimited list of device names.  Root logins will be allowed only upon these devices.
 # This variable is used by login and su.
-#CONSOLE	/etc/consoles
-#CONSOLE	console:tty01:tty02:tty03:tty04
+#CONSOLE           /etc/consoles
+#CONSOLE           console:tty01:tty02:tty03:tty04
 
 # List of groups to add to the user's supplementary group set when logging in on the console (as determined by the `CONSOLE` setting).  Default is none.
 # Use with caution - it is possible for users to gain permanent access to these groups, even when not logged in on the console. How to do it is left as an exercise for the reader...
 # This variable is used by login and su.
-#CONSOLE_GROUPS		floppy:audio:cdrom
+#CONSOLE_GROUPS    floppy:audio:cdrom
 
 # If set to `MD5`, MD5-based algorithm will be used for encrypting password
 # If set to `SHA256`, SHA256-based algorithm will be used for encrypting password
@@ -159,15 +159,15 @@ DEFAULT_HOME	{{ 'yes' if os_auth_allow_homeless else 'no' }}
 #
 # Note: It is recommended to use a value consistent with
 # the PAM modules configuration.
-MD5_CRYPT_ENAB no
-ENCRYPT_METHOD SHA512
+MD5_CRYPT_ENAB    no
+ENCRYPT_METHOD    SHA512
 
 # Only used if `ENCRYPT_METHOD` is set to `SHA256` or `SHA512`: Define the number of SHA rounds.
 # With a lot of rounds, it is more difficult to brute forcing the password. But note also that it more CPU resources will be needed to authenticate users.
 # If not specified, the libc will choose the default number of rounds (5000). The values must be inside the 1000-999999999 range. If only one of the MIN or MAX values is set, then this value will be used.
 # If MIN > MAX, the highest value will be used.
-#SHA_CRYPT_MIN_ROUNDS 5000
-#SHA_CRYPT_MAX_ROUNDS 5000
+#SHA_CRYPT_MIN_ROUNDS    5000
+#SHA_CRYPT_MAX_ROUNDS    5000
 
 
 # Obsoleted by PAM
@@ -208,5 +208,3 @@ ENCRYPT_METHOD SHA512
 # This variable is deprecated. You should use ENCRYPT_METHOD.
 #
 #MD5_CRYPT_ENAB no
-
-

--- a/templates/etc/login.defs.j2
+++ b/templates/etc/login.defs.j2
@@ -26,7 +26,7 @@ MAIL_DIR          {{ os_useradd_mail_dir }}
 
 {% if os_useradd_create_home is defined %}
 # If useradd should create home directories for users by default
-CREATE_HOME	      {{ 'yes' if os_useradd_create_home else 'no' }}
+CREATE_HOME       {{ 'yes' if os_useradd_create_home else 'no' }}
 
 {% endif %}
 # Enable logging and display of `/var/log/faillog` login failure info. This option conflicts with the `pam_tally` PAM module.

--- a/templates/etc/login.defs.j2
+++ b/templates/etc/login.defs.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
+
 # Configuration control definitions for the login package.
 #
 # Three items must be defined:  `MAIL_DIR`, `ENV_SUPATH`, and `ENV_PATH`. If unspecified, some arbitrary (and possibly incorrect) value will be assumed.  All other items are optional - if not specified then the described action or option will be inhibited.

--- a/templates/etc/pam.d/rhel_system_auth.j2
+++ b/templates/etc/pam.d/rhel_system_auth.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
 
 #%PAM-1.0
 {% if os_auth_retries > 0 %}

--- a/templates/etc/profile.d/profile.conf.j2
+++ b/templates/etc/profile.d/profile.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
 
 # Disable core dumps via soft limits for all users. Compliance to this setting is voluntary and can be modified by users up to a hard limit. This setting is a sane default.
 ulimit -S -c 0 > /dev/null 2>&1

--- a/templates/etc/securetty.j2
+++ b/templates/etc/securetty.j2
@@ -1,5 +1,4 @@
-# {{ ansible_managed | comment }}
-
+{{ ansible_managed | comment }}
 
 # A list of TTYs, from which root can log in
 # see `man securetty` for reference

--- a/templates/etc/sysconfig/rhel_sysconfig_init.j2
+++ b/templates/etc/sysconfig/rhel_sysconfig_init.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed | comment }}
+{{ ansible_managed | comment }}
 
 # color => new RH6.0 bootup
 # verbose => old-style bootup

--- a/templates/usr/share/pam-configs/pam_passwdqd.j2
+++ b/templates/usr/share/pam-configs/pam_passwdqd.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 Name: passwdqc password strength enforcement
 Default: yes
 Priority: 1024

--- a/templates/usr/share/pam-configs/pam_tally2.j2
+++ b/templates/usr/share/pam-configs/pam_tally2.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 Name: tally2 lockout after failed attempts enforcement
 Default: yes
 Priority: 1024

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -27,6 +27,9 @@ os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 999
 
+# defaults for useradd
+os_useradd_mail_dir: /var/mail
+
 modprobe_package: 'kmod'
 auditd_package: 'auditd'
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -27,5 +27,9 @@ os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
 
+# defaults for useradd
+os_useradd_mail_dir: /var/spool/mail
+os_useradd_create_home: true
+
 modprobe_package: 'module-init-tools'
 auditd_package: 'audit'

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -27,5 +27,8 @@ os_auth_sys_uid_max: 499
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 499
 
+# defaults for useradd
+os_useradd_create_home: false
+
 modprobe_package: 'kmod-compat'
 auditd_package: 'audit'


### PR DESCRIPTION
The main purpose of this PR is to make the useradd defaults `MAIL_DIR` and `CREATE_HOME` dependent on the OS (fixes: #265). Other minor changes included in this PR are:

- using the `ansible_managed` header correctly in each of the templates
- using a consistent indentation in login.defs and therefore make it easier to read
- removed the duplicate key `kernel.kptr_restrict` in `defaults/main.yml` introduced in #263
