### PR TITLE
Use Python 3 on Centos 8

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,8 @@
     - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
       set_fact:
         ansible_python_interpreter: "/usr/bin/python3"
-      when: ansible_facts.distribution == 'Fedora'
+      when: (ansible_facts.distribution == 'Fedora') or
+            (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8")
 
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
@@ -79,7 +80,8 @@
     - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
       set_fact:
         ansible_python_interpreter: "/usr/bin/python3"
-      when: ansible_facts.distribution == 'Fedora'
+      when: (ansible_facts.distribution == 'Fedora') or
+            (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8")
 
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,7 @@
   roles:
     - ansible-os-hardening
   pre_tasks:
-    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
+    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora/Centos 8+
       set_fact:
         ansible_python_interpreter: "/usr/bin/python3"
       when: (ansible_facts.distribution == 'Fedora') or
@@ -77,7 +77,7 @@
   vars:
     os_auditd_enabled: false
   pre_tasks:
-    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
+    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora/Centos 8+
       set_fact:
         ansible_python_interpreter: "/usr/bin/python3"
       when: (ansible_facts.distribution == 'Fedora') or


### PR DESCRIPTION
This is the main python dist on Centos 8 now so set the default python version similarly to Fedora