### PR TITLE
purge insecure packages

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -3,4 +3,5 @@
   apt:
     name: '{{ os_security_packages_list }}'
     state: 'absent'
+    purge: 'yes'
   when: os_security_packages_clean | bool


### PR DESCRIPTION
This PR makes sure that insecure packages are not just removed but completely purged. Otherwise the packages may still be on the system.