### PR TITLE
Mount proc filesystem using hidepid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you're using Docker / Kubernetes+Docker you'll need to override the ipv4 ip f
 | `os_auditd_enabled` | true | Set to false to disable installing and configuring auditd. |
 | `os_auditd_max_log_file_action` | `keep_logs` | Defines the behaviour of auditd when its log file is filled up. Possible other values are described in the auditd.conf man page. The most common alternative to the default may be `rotate`. |
 | `hidepid_option` | `2` | `0`: This is the default setting and gives you the default behaviour. `1`: With this option an normal user would not see other processes but their own about ps, top etc, but he is still able to see process IDs in /proc. `2`: Users are only able too see their own processes (like with hidepid=1), but also the other process IDs are hidden for them in /proc. |
-| `proc_mnt_options` | `defaults,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }},gid=root` | Mount proc with hardenized options, including `hidepid` with variable value. |
+| `proc_mnt_options` | `rw,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }}` | Mount proc with hardenized options, including `hidepid` with variable value. |
 
 ## Packages
 
@@ -226,4 +226,3 @@ limitations under the License.
 [1]: http://travis-ci.org/dev-sec/ansible-os-hardening
 [2]: https://gitter.im/dev-sec/general
 [3]: https://galaxy.ansible.com/dev-sec/os-hardening
-

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ If you're using Docker / Kubernetes+Docker you'll need to override the ipv4 ip f
 | `ufw_default_forward_policy` | DROP | set default forward policy of ufw to `DROP` |
 | `os_auditd_enabled` | true | Set to false to disable installing and configuring auditd. |
 | `os_auditd_max_log_file_action` | `keep_logs` | Defines the behaviour of auditd when its log file is filled up. Possible other values are described in the auditd.conf man page. The most common alternative to the default may be `rotate`. |
+| `hidepid_option` | `2` | `0`: This is the default setting and gives you the default behaviour. `1`: With this option an normal user would not see other processes but their own about ps, top etc, but he is still able to see process IDs in /proc. `2`: Users are only able too see their own processes (like with hidepid=1), but also the other process IDs are hidden for them in /proc. |
+| `proc_mnt_options` | `defaults,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }},gid=root` | Mount proc with hardenized options, including `hidepid` with variable value. |
 
 ## Packages
 
@@ -224,3 +226,4 @@ limitations under the License.
 [1]: http://travis-ci.org/dev-sec/ansible-os-hardening
 [2]: https://gitter.im/dev-sec/general
 [3]: https://galaxy.ansible.com/dev-sec/os-hardening
+

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -50,9 +50,9 @@
   when: '"change_user" not in os_security_users_allow'
 
 - name: Ensure file /etc/fstab exists
-  stats:
+  stat:
     path: /etc/fstab
-  register: fstab
+  register: fstab_file
 
 - name: Create proc mount point
   file:
@@ -61,7 +61,7 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
-	when: fstab.stat.exists
+	when: fstab_file.stat.exists
 
 - name: set option hidepid for proc filesystem
   lineinfile:
@@ -71,4 +71,4 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
-	when: fstab.stat.exists
+	when: fstab_file.stat.exists

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -49,7 +49,7 @@
     mode: '0750'
   when: '"change_user" not in os_security_users_allow'
 
-- name: Check if file /etc/fstab exists
+- name: Ensure file /etc/fstab exists
    stat:
      path: /etc/fstab
    register: fstab

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -48,3 +48,15 @@
     group: 'root'
     mode: '0750'
   when: '"change_user" not in os_security_users_allow'
+
+- name: set option hidepid for proc filesystem
+  lineinfile:
+    path: /etc/fstab
+    regexp: '^proc.*'
+    line: '{{ proc_hidepid_entry }}'
+    owner: '{{ os_passwd_perms.owner }}'
+    group: '{{ os_passwd_perms.group }}'
+    mode: '{{ os_passwd_perms.mode }}'
+
+- name: remount filesystem
+  shell: mount -a

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -49,26 +49,11 @@
     mode: '0750'
   when: '"change_user" not in os_security_users_allow'
 
-- name: Ensure file /etc/fstab exists
-  stat:
-    path: /etc/fstab
-  register: fstab_file
-
-- name: Create proc mount point
-  file:
-    path: /proc
-    state: directory
-    owner: '{{ os_passwd_perms.owner }}'
-    group: '{{ os_passwd_perms.group }}'
-    mode: '{{ os_passwd_perms.mode }}'
-  when: fstab_file.stat.exists
-
 - name: set option hidepid for proc filesystem
-  lineinfile:
-    path: /etc/fstab
-    regexp: '^proc.*'
-    line: '{{ proc_hidepid_entry }}'
-    owner: '{{ os_passwd_perms.owner }}'
-    group: '{{ os_passwd_perms.group }}'
-    mode: '{{ os_passwd_perms.mode }}'
-  when: fstab_file.stat.exists
+  mount:
+    path: /proc
+    src: proc
+    fstype: proc
+    opts: '{{ proc_mnt_options }}' 
+    state: present
+  tags: [test]

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -56,4 +56,3 @@
     fstype: proc
     opts: '{{ proc_mnt_options }}' 
     state: present
-  tags: [test]

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -61,7 +61,7 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
-	when: fstab_file.stat.exists
+  when: fstab_file.stat.exists
 
 - name: set option hidepid for proc filesystem
   lineinfile:
@@ -71,4 +71,4 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
-	when: fstab_file.stat.exists
+  when: fstab_file.stat.exists

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -57,6 +57,3 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
-
-- name: remount filesystem
-  shell: mount -a

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -49,6 +49,11 @@
     mode: '0750'
   when: '"change_user" not in os_security_users_allow'
 
+- name: Check if file /etc/fstab exists
+   stat:
+     path: /etc/fstab
+   register: fstab
+
 - name: Create proc mount point
   file:
     path: /proc
@@ -56,6 +61,7 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
+	when: fstab.stat.exists
 
 - name: set option hidepid for proc filesystem
   lineinfile:
@@ -65,3 +71,4 @@
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
+	when: fstab.stat.exists

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -50,9 +50,9 @@
   when: '"change_user" not in os_security_users_allow'
 
 - name: Ensure file /etc/fstab exists
-   stat:
-     path: /etc/fstab
-   register: fstab
+  stats:
+    path: /etc/fstab
+  register: fstab
 
 - name: Create proc mount point
   file:

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -54,5 +54,5 @@
     path: /proc
     src: proc
     fstype: proc
-    opts: '{{ proc_mnt_options }}' 
+    opts: '{{ proc_mnt_options }}'
     state: present

--- a/tasks/minimize_access.yml
+++ b/tasks/minimize_access.yml
@@ -49,6 +49,14 @@
     mode: '0750'
   when: '"change_user" not in os_security_users_allow'
 
+- name: Create proc mount point
+  file:
+    path: /proc
+    state: directory
+    owner: '{{ os_passwd_perms.owner }}'
+    group: '{{ os_passwd_perms.group }}'
+    mode: '{{ os_passwd_perms.mode }}'
+
 - name: set option hidepid for proc filesystem
   lineinfile:
     path: /etc/fstab

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -109,3 +109,5 @@ os_security_suid_sgid_system_whitelist:
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
+
+proc_hidepid_entry: 'proc                    /proc                   proc    defaults,nosuid,nodev,noexec,relatime,hidepid=2,gid=root    0 0'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -110,4 +110,5 @@ os_security_suid_sgid_system_whitelist:
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
 
-proc_hidepid_entry: 'proc                    /proc                   proc    defaults,nosuid,nodev,noexec,relatime,hidepid=2,gid=root    0 0'
+hidepid_option: '2' # allowed values: 0, 1, 2 
+proc_mnt_options: 'defaults,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }},gid=root'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -110,5 +110,5 @@ os_security_suid_sgid_system_whitelist:
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
 
-hidepid_option: '2' # allowed values: 0, 1, 2 
+hidepid_option: '2' # allowed values: 0, 1, 2
 proc_mnt_options: 'defaults,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }},gid=root'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -111,4 +111,4 @@ os_security_suid_sgid_system_whitelist:
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
 
 hidepid_option: '2' # allowed values: 0, 1, 2
-proc_mnt_options: 'defaults,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }},gid=root'
+proc_mnt_options: 'rw,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }}'


### PR DESCRIPTION
Hi, I think could be a good idea to include this task as a basic os hardening option.
I recently discovered this nice option and now I'm going to use it wherever possible.
Do you agree with this? 
Let me know about your opinion. 