### PR TITLE
do not blacklist used filesystems

### DIFF
--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -17,6 +17,7 @@
 - name: remove used filesystems from fs-list
   set_fact:
     os_unused_filesystems: "{{ os_unused_filesystems | difference(ansible_mounts | map(attribute='fstype') | list) }}"
+  # we cannot do this on el6 and below, because these systems don't support the map function
   when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7')
 
 - name: disable unused filesystems | os-10

--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -14,11 +14,9 @@
     os_unused_filesystems: "{{ os_unused_filesystems | difference('vfat') }}"
   when: efi_installed.stat.isdir is defined and efi_installed.stat.isdir
 
-# some systems seem to require /boot/efi mounted while not exposing /sys/firmware/efi
-- name: remove vfat from fs-list if /boot/efi is mounted
+- name: remove used filesystems from fs-list
   set_fact:
-    os_unused_filesystems: "{{ os_unused_filesystems | difference('vfat') }}"
-  when: ('vfat' in ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | map(attribute='fstype') | list)
+    os_unused_filesystems: "{{ os_unused_filesystems | difference(ansible_mounts | map(attribute='fstype') | list) }}"
 
 - name: disable unused filesystems | os-10
   template:

--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -14,6 +14,12 @@
     os_unused_filesystems: "{{ os_unused_filesystems | difference('vfat') }}"
   when: efi_installed.stat.isdir is defined and efi_installed.stat.isdir
 
+# some systems seem to require /boot/efi mounted while not exposing /sys/firmware/efi
+- name: remove vfat from fs-list if /boot/efi is mounted
+  set_fact:
+    os_unused_filesystems: "{{ os_unused_filesystems | difference('vfat') }}"
+  when: ('vfat' in "{{ ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | map(attribute='fstype') | list  }}")
+
 - name: disable unused filesystems | os-10
   template:
     src: 'etc/modprobe.d/modprobe.j2'

--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -17,6 +17,7 @@
 - name: remove used filesystems from fs-list
   set_fact:
     os_unused_filesystems: "{{ os_unused_filesystems | difference(ansible_mounts | map(attribute='fstype') | list) }}"
+  when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7')
 
 - name: disable unused filesystems | os-10
   template:

--- a/tasks/modprobe.yml
+++ b/tasks/modprobe.yml
@@ -18,7 +18,7 @@
 - name: remove vfat from fs-list if /boot/efi is mounted
   set_fact:
     os_unused_filesystems: "{{ os_unused_filesystems | difference('vfat') }}"
-  when: ('vfat' in "{{ ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | map(attribute='fstype') | list  }}")
+  when: ('vfat' in ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | map(attribute='fstype') | list)
 
 - name: disable unused filesystems | os-10
   template:


### PR DESCRIPTION
some systems seem to require vfat because of efi, despite not exposing a
/sys/firmware/efi directory.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>