### PR TITLE
use find module instead of shell

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -3,7 +3,7 @@
   file:
     name: '/etc/yum.repos.d/{{ item }}.repo'
     state: 'absent'
-  with_items:
+  loop:
     - 'CentOS-Debuginfo'
     - 'CentOS-Media'
     - 'CentOS-Vault'
@@ -36,7 +36,7 @@
     line: 'gpgcheck=1'
   register: status
   failed_when: status.rc is defined and status.rc != 257
-  with_items:
+  loop:
     - '/etc/yum.conf'
     - '/etc/dnf/dnf.conf'
     - '/etc/yum/pluginconf.d/rhnplugin.conf'

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -30,7 +30,7 @@
 # status.rc is only defined if an error accrued and only error code (rc) 257 will be ignored.
 # All other errors will still be raised.
 - name: activate gpg-check for config files
-  lineinfile:
+  replace:
     path: '{{ item }}'
     regexp: '^\s*gpgcheck\W.*'
     line: 'gpgcheck=1'

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -10,28 +10,35 @@
   when: os_security_packages_clean | bool
 
 - name: get yum-repository-files
-  shell: 'find /etc/yum.repos.d/ -type f -name *.repo'
-  changed_when: False
+  find:
+    paths: '/etc/yum.repos.d'
+    patterns: '*.repo'
   register: yum_repos
 
-  # for the 'default([])' see here:
-  # https://github.com/dev-sec/ansible-os-hardening/issues/99 and
-  # https://stackoverflow.com/questions/37067827/ansible-deprecation-warning-for-undefined-variable-despite-when-clause
-  #
-  # failed_when is needed because by default replace module will fail if the file doesn't exists.
-  # status.rc is only defined if an error accrued and only error code (rc) 257 will be ignored.
-  # All other errors will still be raised.
-- name: activate gpg-check for config files
+# for the 'default([])' see here:
+# https://github.com/dev-sec/ansible-os-hardening/issues/99 and
+# https://stackoverflow.com/questions/37067827/ansible-deprecation-warning-for-undefined-variable-despite-when-clause
+- name: activate gpg-check for yum-repository-files
   replace:
-    dest: '{{ item }}'
-    regexp: '^\s*gpgcheck: 0'
-    replace: 'gpgcheck: 1'
+    path: '{{ item.path }}'
+    regexp: '^\s*gpgcheck.*'
+    replace: 'gpgcheck=1'
+  with_items:
+    - '{{ yum_repos.files | default([]) }}'
+
+# failed_when is needed because by default replace module will fail if the file doesn't exists.
+# status.rc is only defined if an error accrued and only error code (rc) 257 will be ignored.
+# All other errors will still be raised.
+- name: activate gpg-check for config files
+  lineinfile:
+    path: '{{ item }}'
+    regexp: '^\s*gpgcheck\W.*'
+    line: 'gpgcheck=1'
   register: status
   failed_when: status.rc is defined and status.rc != 257
-  with_flattened:
+  with_items:
     - '/etc/yum.conf'
     - '/etc/dnf/dnf.conf'
-    - '{{ yum_repos.stdout_lines| default([]) }}' # noqa 104
     - '/etc/yum/pluginconf.d/rhnplugin.conf'
 
 - name: remove deprecated or insecure packages | package-01 - package-09


### PR DESCRIPTION
- replace `shell` by `find` module
- regexp fixes when activating gpgcheck to cover more scenarios

solves: https://github.com/dev-sec/ansible-os-hardening/issues/293

Signed-off-by: danielkubat <dan.kubat@gmail.com>

