### PR TITLE
replace module parameter fixed

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -33,7 +33,7 @@
   replace:
     path: '{{ item }}'
     regexp: '^\s*gpgcheck\W.*'
-    line: 'gpgcheck=1'
+    replace: 'gpgcheck=1'
   register: status
   failed_when: status.rc is defined and status.rc != 257
   loop:


### PR DESCRIPTION
`replace` module parameter to to replace regexp matches is _replace,_ not `line`

https://docs.ansible.com/ansible/latest/modules/replace_module.html#parameter-replace

Signed-off-by: danielkubat <dan.kubat@gmail.com>