### PR TITLE
file permissions explicitly defined

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -72,6 +72,7 @@
   template:
     src: 'etc/default/ufw.j2'
     dest: '/etc/default/ufw'
+    mode: 0644
   when:
     - ufw_manage_defaults
     - ansible_facts.distribution in ['Debian', 'Ubuntu']

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -72,7 +72,7 @@
   template:
     src: 'etc/default/ufw.j2'
     dest: '/etc/default/ufw'
-    mode: 0644
+    mode: '0644'
   when:
     - ufw_manage_defaults
     - ansible_facts.distribution in ['Debian', 'Ubuntu']

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -23,7 +23,7 @@
     path: '{{ item.path }}'
     regexp: '^\s*gpgcheck.*'
     replace: 'gpgcheck=1'
-    mode: preserve
+    mode: 0644
   with_items:
     - '{{ yum_repos.files | default([]) }}'
 
@@ -35,7 +35,7 @@
     path: '{{ item }}'
     regexp: '^\s*gpgcheck\W.*'
     replace: 'gpgcheck=1'
-    mode: preserve
+    mode: 0644
   register: status
   failed_when: status.rc is defined and status.rc != 257
   loop:

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -23,6 +23,7 @@
     path: '{{ item.path }}'
     regexp: '^\s*gpgcheck.*'
     replace: 'gpgcheck=1'
+    mode: preserve
   with_items:
     - '{{ yum_repos.files | default([]) }}'
 
@@ -34,6 +35,7 @@
     path: '{{ item }}'
     regexp: '^\s*gpgcheck\W.*'
     replace: 'gpgcheck=1'
+    mode: preserve
   register: status
   failed_when: status.rc is defined and status.rc != 257
   loop:

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -23,7 +23,7 @@
     path: '{{ item.path }}'
     regexp: '^\s*gpgcheck.*'
     replace: 'gpgcheck=1'
-    mode: 0644
+    mode: '0644'
   with_items:
     - '{{ yum_repos.files | default([]) }}'
 
@@ -35,7 +35,7 @@
     path: '{{ item }}'
     regexp: '^\s*gpgcheck\W.*'
     replace: 'gpgcheck=1'
-    mode: 0644
+    mode: '0644'
   register: status
   failed_when: status.rc is defined and status.rc != 257
   loop:


### PR DESCRIPTION
due to breaking change in recent `ansible-lint` release, we need to add file permissions (mode) - there are no default ones anymore due to security concerns.

fixes: https://github.com/dev-sec/ansible-os-hardening/issues/299

Signed-off-by: danielkubat <dan.kubat@gmail.com>