### PR TITLE
added sysctl_config_blacklist variable to filter the sys_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you're using Docker / Kubernetes+Docker you'll need to override the ipv4 ip f
 | `os_auditd_max_log_file_action` | `keep_logs` | Defines the behaviour of auditd when its log file is filled up. Possible other values are described in the auditd.conf man page. The most common alternative to the default may be `rotate`. |
 | `hidepid_option` | `2` | `0`: This is the default setting and gives you the default behaviour. `1`: With this option an normal user would not see other processes but their own about ps, top etc, but he is still able to see process IDs in /proc. `2`: Users are only able too see their own processes (like with hidepid=1), but also the other process IDs are hidden for them in /proc. |
 | `proc_mnt_options` | `rw,nosuid,nodev,noexec,relatime,hidepid={{ hidepid_option }}` | Mount proc with hardenized options, including `hidepid` with variable value. |
+| `sysctl_config_blacklist` | [] | filter the default sysctl_config options which are applied. Add all options which should not be applied to this variable.|
 
 ## Packages
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,7 @@ ufw_default_application_policy: 'SKIP'
 ufw_manage_builtins: 'no'
 ufw_ipt_modules: 'nf_conntrack_ftp nf_nat_ftp nf_conntrack_netbios_ns'
 
+sysctl_config_blacklist: []
 sysctl_config:
   # Disable IPv4 traffic forwarding. | sysctl-01
   net.ipv4.ip_forward: 0

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -43,8 +43,12 @@
   block:
     - name: create a combined sysctl-dict if overwrites are defined
       set_fact:
-        sysctl_config: '{{ sysctl_config | combine(sysctl_overwrite) }}'
+        sysctl_config: '{{ sysctl_config | combine(sysctl_overwrite)}}'
       when: sysctl_overwrite | default()
+
+    - name: filter sysctl_config by sysctl_config_blacklist
+      set_fact:
+        sysctl_config: "{% set res = {} %}{% for key in sysctl_config.keys() %}{% if key not in sysctl_config_blacklist %}{% set ignored = res.update({ key: sysctl_config[key]}) %}{% endif %}{% endfor %}{{ res }}"
 
     - name: Change various sysctl-settings, look at the sysctl-vars file for documentation
       sysctl:


### PR DESCRIPTION
On my system could not apply all sys_config options which are applied per default. Thus i added a variable sysctl_config_blacklist to filter/exclude specific sys_config options to be applied. 

